### PR TITLE
allow specification of extra headers on backing requests

### DIFF
--- a/caboose.go
+++ b/caboose.go
@@ -20,7 +20,8 @@ type Config struct {
 	LoggingClient   *http.Client
 	LoggingInterval time.Duration
 
-	Client *http.Client
+	Client       *http.Client
+	ExtraHeaders *http.Header
 
 	DoValidation   bool
 	AffinityKey    string

--- a/pool.go
+++ b/pool.go
@@ -227,13 +227,22 @@ func (p *pool) doFetch(ctx context.Context, from string, c cid.Cid) (b blocks.Bl
 	if err != nil {
 		return nil, err
 	}
-	resp, err := p.config.Client.Do(&http.Request{
+	req := http.Request{
 		Method: http.MethodGet,
 		URL:    u,
 		Header: http.Header{
 			"Accept": []string{"application/vnd.ipld.raw"},
 		},
-	})
+	}
+	if p.config.ExtraHeaders != nil {
+		for k, vs := range *p.config.ExtraHeaders {
+			for _, v := range vs {
+				req.Header.Add(k, v)
+			}
+		}
+	}
+
+	resp, err := p.config.Client.Do(&req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fix #13 

When deployed in `bifrost-gateway` we should include {`x-fetcher`: `bifrost-gateway/<version>`} to indicate to backing nodes what is requesting