### PR TITLE
fix: change block level logs to debug

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -198,7 +198,7 @@ func (p *pool) doFetch(ctx context.Context, from string, c cid.Cid) (b blocks.Bl
 	respReq := &http.Request{}
 	received := 0
 	defer func() {
-		goLogger.Infow("fetch result", "from", from, "of", c, "status", code, "size", received, "ttfb", int(fb.Sub(start).Milliseconds()), "duration", time.Since(start).Seconds())
+		goLogger.Debugw("fetch result", "from", from, "of", c, "status", code, "size", received, "ttfb", int(fb.Sub(start).Milliseconds()), "duration", time.Since(start).Seconds())
 		fetchResponseMetric.WithLabelValues(fmt.Sprintf("%d", code)).Add(1)
 		if e == nil {
 			fetchLatencyMetric.Observe(float64(fb.Sub(start).Milliseconds()))
@@ -263,7 +263,6 @@ func (p *pool) doFetch(ctx context.Context, from string, c cid.Cid) (b blocks.Bl
 			return nil, blocks.ErrWrongHash
 		}
 		if !nc.Equals(c) {
-			fmt.Printf("got %s vs %s\n", nc, c)
 			return nil, blocks.ErrWrongHash
 		}
 	}


### PR DESCRIPTION
This changes the logging level of block requests to debug and removes the `fmt.Println`.