### PR TITLE
fix: request honours upstream context

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -223,17 +222,12 @@ func (p *pool) doFetch(ctx context.Context, from string, c cid.Cid) (b blocks.Bl
 			UserAgent:     respReq.UserAgent(),
 		}
 	}()
-	u, err := url.Parse(fmt.Sprintf(tmpl, from, c))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf(tmpl, from, c), nil)
 	if err != nil {
 		return nil, err
 	}
-	req := &http.Request{
-		Method: http.MethodGet,
-		URL:    u,
-		Header: http.Header{
-			"Accept": []string{"application/vnd.ipld.raw"},
-		},
-	}
+
+	req.Header.Add("Accept", "application/vnd.ipld.raw")
 	if p.config.ExtraHeaders != nil {
 		for k, vs := range *p.config.ExtraHeaders {
 			for _, v := range vs {
@@ -241,7 +235,6 @@ func (p *pool) doFetch(ctx context.Context, from string, c cid.Cid) (b blocks.Bl
 			}
 		}
 	}
-	req = req.WithContext(ctx)
 
 	resp, err := p.config.Client.Do(req)
 	if err != nil {

--- a/pool.go
+++ b/pool.go
@@ -227,7 +227,7 @@ func (p *pool) doFetch(ctx context.Context, from string, c cid.Cid) (b blocks.Bl
 	if err != nil {
 		return nil, err
 	}
-	req := http.Request{
+	req := &http.Request{
 		Method: http.MethodGet,
 		URL:    u,
 		Header: http.Header{
@@ -241,8 +241,9 @@ func (p *pool) doFetch(ctx context.Context, from string, c cid.Cid) (b blocks.Bl
 			}
 		}
 	}
+	req = req.WithContext(ctx)
 
-	resp, err := p.config.Client.Do(&req)
+	resp, err := p.config.Client.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Ensure the request to saturn uses the context and doesn't keep running if the upstream context has been canceled.