### PR TITLE
 Fix bugs, refactor, document and land the weighted consistent hashing branch

### DIFF
--- a/caboose.go
+++ b/caboose.go
@@ -37,9 +37,9 @@ type Config struct {
 	// PoolRefresh is the interval at which we refresh the pool of Saturn nodes.
 	PoolRefresh time.Duration
 
-	// PoolFailureDownvoteDebounce is the amount of time we wait between consecutive updates to the weight of a Saturn node
+	// PoolWeightChangeDebounce is the amount of time we wait between consecutive updates to the weight of a Saturn node
 	// in our pool after a retrieval success/failure.
-	PoolFailureDownvoteDebounce time.Duration
+	PoolWeightChangeDebounce time.Duration
 
 	// trigger early refreshes when pool size drops below this low watermark
 	PoolLowWatermark int
@@ -73,8 +73,8 @@ func NewCaboose(config *Config) (ipfsblockstore.Blockstore, error) {
 			Timeout: DefaultSaturnRequestTimeout,
 		}
 	}
-	if c.config.PoolFailureDownvoteDebounce == 0 {
-		c.config.PoolFailureDownvoteDebounce = DefaultPoolFailureDownvoteDebounce
+	if c.config.PoolWeightChangeDebounce == 0 {
+		c.config.PoolWeightChangeDebounce = DefaultPoolFailureDownvoteDebounce
 	}
 	if c.config.PoolLowWatermark == 0 {
 		c.config.PoolLowWatermark = DefaultPoolLowWatermark

--- a/caboose.go
+++ b/caboose.go
@@ -18,27 +18,27 @@ type Config struct {
 	// OrchestratorClient is the HTTP client to use when communicating with the Saturn orchestrator.
 	OrchestratorClient *http.Client
 
-	// LoggingEndpoint is the URL of the Caboose logging endpoint where we submit the logs pertaining to our Saturn retrieval requests.
+	// LoggingEndpoint is the URL of the logging endpoint where we submit logs pertaining to our Saturn retrieval requests.
 	LoggingEndpoint url.URL
-	// LoggingClient is the HTTP client to use when communicating with the Caboose logging endpoint.
+	// LoggingClient is the HTTP client to use when communicating with the logging endpoint.
 	LoggingClient *http.Client
-	// LoggingInterval is the interval at which we submit logs to the Caboose logging endpoint.
+	// LoggingInterval is the interval at which we submit logs to the logging endpoint.
 	LoggingInterval time.Duration
 
 	// SaturnClient is the HTTP client to use when retrieving content from the Saturn network.
 	SaturnClient *http.Client
 	ExtraHeaders *http.Header
 
-	// DoValidation is used to determine if Caboose should validate the blocks recieved from the Saturn network.
+	// DoValidation is used to determine if we should validate the blocks recieved from the Saturn network.
 	DoValidation bool
-	// If set, AffinityKey is used instead of the block cid as the key on the consistent hashing ring
-	// to decide which Saturn node to retrieve the block from.
+	// If set, AffinityKey is used instead of the block cid as the key on the Saturn node pool
+	// to determine which Saturn node to retrieve the block from.
 	AffinityKey string
 	// PoolRefresh is the interval at which we refresh the pool of Saturn nodes.
 	PoolRefresh time.Duration
 
-	// PoolFailureDownvoteDebounce is the amount of time we wait between consecutive downvotings of a Saturn node
-	// on our consistent hashing ring after a retrieval failure.
+	// PoolFailureDownvoteDebounce is the amount of time we wait between consecutive updates to the weight of a Saturn node
+	// in our pool after a retrieval success/failure.
 	PoolFailureDownvoteDebounce time.Duration
 
 	// trigger early refreshes when pool size drops below this low watermark

--- a/caboose.go
+++ b/caboose.go
@@ -55,8 +55,8 @@ const maxBlockSize = 4194305 // 4 Mib + 1 byte
 const DefaultOrchestratorEndpoint = "https://orchestrator.strn.pl/nodes/nearby?count=1000"
 
 var ErrNotImplemented error = errors.New("not implemented")
-var ErrNoBackend error = errors.New("no available backend")
-var ErrBackendFailed error = errors.New("backend failed")
+var ErrNoBackend error = errors.New("no available strn backend")
+var ErrBackendFailed error = errors.New("strn backend failed")
 
 type Caboose struct {
 	config *Config

--- a/caboose.go
+++ b/caboose.go
@@ -50,6 +50,7 @@ type Config struct {
 const DefaultMaxRetries = 3
 const DefaultPoolFailureDownvoteDebounce = time.Second
 const DefaultPoolLowWatermark = 5
+const DefaultSaturnRequestTimeout = 19 * time.Second
 
 var ErrNotImplemented error = errors.New("not implemented")
 var ErrNoBackend error = errors.New("no available backend")
@@ -68,7 +69,9 @@ func NewCaboose(config *Config) (ipfsblockstore.Blockstore, error) {
 	}
 	c.pool.logger = c.logger
 	if c.config.SaturnClient == nil {
-		c.config.SaturnClient = http.DefaultClient
+		c.config.SaturnClient = &http.Client{
+			Timeout: DefaultSaturnRequestTimeout,
+		}
 	}
 	if c.config.PoolFailureDownvoteDebounce == 0 {
 		c.config.PoolFailureDownvoteDebounce = DefaultPoolFailureDownvoteDebounce

--- a/caboose.go
+++ b/caboose.go
@@ -51,9 +51,11 @@ const DefaultMaxRetries = 3
 const DefaultPoolFailureDownvoteDebounce = time.Second
 const DefaultPoolLowWatermark = 5
 const DefaultSaturnRequestTimeout = 19 * time.Second
+const maxBlockSize = 4194305 // 4 Mib + 1 byte
 
 var ErrNotImplemented error = errors.New("not implemented")
 var ErrNoBackend error = errors.New("no available backend")
+var ErrBackendFailed error = errors.New("backend failed")
 
 type Caboose struct {
 	config *Config

--- a/caboose.go
+++ b/caboose.go
@@ -14,7 +14,7 @@ import (
 
 type Config struct {
 	// OrchestratorEndpoint is the URL of the Saturn orchestrator.
-	OrchestratorEndpoint url.URL
+	OrchestratorEndpoint *url.URL
 	// OrchestratorClient is the HTTP client to use when communicating with the Saturn orchestrator.
 	OrchestratorClient *http.Client
 
@@ -52,6 +52,7 @@ const DefaultPoolFailureDownvoteDebounce = time.Second
 const DefaultPoolLowWatermark = 5
 const DefaultSaturnRequestTimeout = 19 * time.Second
 const maxBlockSize = 4194305 // 4 Mib + 1 byte
+const DefaultOrchestratorEndpoint = "https://orchestrator.strn.pl/nodes/nearby?count=1000"
 
 var ErrNotImplemented error = errors.New("not implemented")
 var ErrNoBackend error = errors.New("no available backend")
@@ -75,6 +76,14 @@ func NewCaboose(config *Config) (ipfsblockstore.Blockstore, error) {
 			Timeout: DefaultSaturnRequestTimeout,
 		}
 	}
+	if c.config.OrchestratorEndpoint == nil {
+		var err error
+		c.config.OrchestratorEndpoint, err = url.Parse(DefaultOrchestratorEndpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if c.config.PoolWeightChangeDebounce == 0 {
 		c.config.PoolWeightChangeDebounce = DefaultPoolFailureDownvoteDebounce
 	}

--- a/cmd/caboose/main.go
+++ b/cmd/caboose/main.go
@@ -38,7 +38,6 @@ func main1() int {
 			}
 			out := args.Get(1)
 
-			oe, _ := url.Parse("https://orchestrator.strn.pl/nodes/nearby?count=100")
 			le, _ := url.Parse("https://twb3qukm2i654i3tnvx36char40aymqq.lambda-url.us-west-2.on.aws/")
 			saturnClient := http.Client{
 				Transport: &http.Transport{
@@ -49,7 +48,6 @@ func main1() int {
 			}
 
 			cb, err := caboose.NewCaboose(&caboose.Config{
-				OrchestratorEndpoint: *oe,
 				OrchestratorClient: &http.Client{
 					Timeout: 30 * time.Second,
 				},

--- a/cmd/caboose/main.go
+++ b/cmd/caboose/main.go
@@ -38,7 +38,7 @@ func main1() int {
 			}
 			out := args.Get(1)
 
-			oe, _ := url.Parse("https://orchestrator.strn.pl/nodes/nearby")
+			oe, _ := url.Parse("https://orchestrator.strn.pl/nodes/nearby?count=100")
 			le, _ := url.Parse("https://twb3qukm2i654i3tnvx36char40aymqq.lambda-url.us-west-2.on.aws/")
 			saturnClient := http.Client{
 				Transport: &http.Transport{

--- a/cmd/caboose/main.go
+++ b/cmd/caboose/main.go
@@ -50,7 +50,9 @@ func main1() int {
 
 			cb, err := caboose.NewCaboose(&caboose.Config{
 				OrchestratorEndpoint: *oe,
-				OrchestratorClient:   http.DefaultClient,
+				OrchestratorClient: &http.Client{
+					Timeout: 30 * time.Second,
+				},
 
 				LoggingEndpoint: *le,
 				LoggingClient:   http.DefaultClient,
@@ -58,7 +60,7 @@ func main1() int {
 
 				DoValidation: true,
 				PoolRefresh:  5 * time.Minute,
-				Client:       &saturnClient,
+				SaturnClient: &saturnClient,
 			})
 			if err != nil {
 				return err

--- a/failure_test.go
+++ b/failure_test.go
@@ -2,6 +2,7 @@ package caboose_test
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -36,6 +37,15 @@ func TestCabooseFailures(t *testing.T) {
 		}
 	}))
 
+	saturnClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+				ServerName:         "example.com",
+			},
+		},
+	}
+
 	ourl, _ := url.Parse(orch.URL)
 	c, err := caboose.NewCaboose(&caboose.Config{
 		OrchestratorEndpoint: ourl,
@@ -44,7 +54,7 @@ func TestCabooseFailures(t *testing.T) {
 		LoggingClient:        http.DefaultClient,
 		LoggingInterval:      time.Hour,
 
-		SaturnClient:             http.DefaultClient,
+		SaturnClient:             saturnClient,
 		DoValidation:             false,
 		PoolWeightChangeDebounce: time.Duration(1),
 		PoolRefresh:              time.Millisecond * 50,

--- a/failure_test.go
+++ b/failure_test.go
@@ -43,11 +43,11 @@ func TestCabooseFailures(t *testing.T) {
 		LoggingClient:        http.DefaultClient,
 		LoggingInterval:      time.Hour,
 
-		SaturnClient:                http.DefaultClient,
-		DoValidation:                false,
-		PoolFailureDownvoteDebounce: time.Duration(1),
-		PoolRefresh:                 time.Millisecond * 50,
-		MaxRetrievalAttempts:        2,
+		SaturnClient:             http.DefaultClient,
+		DoValidation:             false,
+		PoolWeightChangeDebounce: time.Duration(1),
+		PoolRefresh:              time.Millisecond * 50,
+		MaxRetrievalAttempts:     2,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/failure_test.go
+++ b/failure_test.go
@@ -17,11 +17,12 @@ import (
 )
 
 func TestCabooseFailures(t *testing.T) {
+
 	pool := make([]ep, 3)
 	purls := make([]string, 3)
 	for i := 0; i < len(pool); i++ {
 		pool[i].Setup()
-		purls[i] = strings.TrimPrefix(pool[i].server.URL, "http://")
+		purls[i] = strings.TrimPrefix(pool[i].server.URL, "https://")
 	}
 	gol := sync.Mutex{}
 	goodOrch := true
@@ -37,7 +38,7 @@ func TestCabooseFailures(t *testing.T) {
 
 	ourl, _ := url.Parse(orch.URL)
 	c, err := caboose.NewCaboose(&caboose.Config{
-		OrchestratorEndpoint: *ourl,
+		OrchestratorEndpoint: ourl,
 		OrchestratorClient:   http.DefaultClient,
 		LoggingEndpoint:      *ourl,
 		LoggingClient:        http.DefaultClient,
@@ -145,7 +146,7 @@ var testBlock = []byte("hello World")
 
 func (e *ep) Setup() {
 	e.valid = true
-	e.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	e.server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		e.cnt++
 		if e.valid {
 			w.Write(testBlock)

--- a/failure_test.go
+++ b/failure_test.go
@@ -43,11 +43,11 @@ func TestCabooseFailures(t *testing.T) {
 		LoggingClient:        http.DefaultClient,
 		LoggingInterval:      time.Hour,
 
-		Client:                      http.DefaultClient,
+		SaturnClient:                http.DefaultClient,
 		DoValidation:                false,
 		PoolFailureDownvoteDebounce: time.Duration(1),
 		PoolRefresh:                 time.Millisecond * 50,
-		MaxRetries:                  2,
+		MaxRetrievalAttempts:        2,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pool.go
+++ b/pool.go
@@ -17,7 +17,9 @@ import (
 	"github.com/serialx/hashring"
 )
 
-// loadPool refreshes the set of endpoints to fetch cars from from the Orchestrator Endpoint
+var l1_discovery_timeout = 1 * time.Minute
+
+// loadPool refreshes the set of Saturn endpoints to fetch cars from the Orchestrator Endpoint
 func (p *pool) loadPool() ([]string, error) {
 	if override := os.Getenv("CABOOSE_BACKEND_OVERRIDE"); len(override) > 0 {
 		return strings.Split(override, ","), nil
@@ -28,6 +30,7 @@ func (p *pool) loadPool() ([]string, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+
 	responses := make([]string, 0)
 	if err := json.NewDecoder(resp.Body).Decode(&responses); err != nil {
 		goLogger.Warnw("failed to decode backends from orchestrator", "err", err, "endpoint", p.config.OrchestratorEndpoint.String())
@@ -38,39 +41,46 @@ func (p *pool) loadPool() ([]string, error) {
 }
 
 type pool struct {
-	config    *Config
-	endpoints MemberList
-	logger    *logger
-	c         *hashring.HashRing
+	config *Config
+	logger *logger
+
+	started chan struct{} // started signals that we've already initialized the pool once with Saturn endpoints.
+	refresh chan struct{} // refresh is used to signal the need for doing a refresh of the Saturn endpoints pool.
+	done    chan struct{} // done is used to signal that we're shutting down the Saturn endpoints pool and don't need to refresh it anymore.
+
 	lk        sync.RWMutex
-	started   chan struct{}
-	refresh   chan struct{}
-	done      chan struct{}
+	endpoints MemberList         // guarded by lk
+	c         *hashring.HashRing // guarded by lk
 }
 
+// MemberList is the list of Saturn endpoints that are currently members of the Caboose consistent hashing ring
+// that determines which Saturn endpoint to use to retrieve a given CID.
 type MemberList []*Member
 
+// ToWeights returns a map of Saturn endpoints to their weight on Caboose's consistent hashing ring.
 func (m MemberList) ToWeights() map[string]int {
 	ml := make(map[string]int, len(m))
 	for _, mm := range m {
-		ml[mm.string] = mm.replication
+		ml[mm.url] = mm.replication
 	}
 	return ml
 }
 
+// Member is a Saturn endpoint that is currently a member of the Caboose consistent hashing ring.
 type Member struct {
-	string
-	sync.Mutex
+	lk sync.Mutex
+
+	url         string
 	lastUpdate  time.Time
 	replication int
 }
 
 func NewMember(addr string) *Member {
-	return &Member{addr, sync.Mutex{}, time.Now(), 20}
+	return &Member{url: addr, lk: sync.Mutex{}, lastUpdate: time.Now(), replication: 20}
 }
 
 func (m *Member) String() string {
-	return string(m.string)
+	return string(m.url)
 }
 
 func (m *Member) ReplicationFactor() int {
@@ -79,16 +89,16 @@ func (m *Member) ReplicationFactor() int {
 
 func (m *Member) Downvote(debounce time.Duration) (*Member, bool) {
 	// this is a best-effort. if there's a correlated failure we ignore the others, so do the try on best-effort.
-	if m.TryLock() {
+	if m.lk.TryLock() {
 		if time.Since(m.lastUpdate) > debounce {
 			// make the down-voted member
-			nm := NewMember(m.string)
+			nm := NewMember(m.url)
 			nm.replication = m.replication / 2
-			m.lastUpdate = time.Now()
-			m.Unlock()
+			nm.lastUpdate = time.Now()
+			m.lk.Unlock()
 			return nm, true
 		}
-		m.Unlock()
+		m.lk.Unlock()
 	}
 	return nil, false
 }
@@ -110,12 +120,19 @@ func (p *pool) doRefresh() {
 	newEP, err := p.loadPool()
 	if err == nil {
 		p.lk.RLock()
+
+		// TODO: The orchestrator periodically prunes "bad" L1s based on a reputation system
+		// it owns and runs. We should probably just forget about the Saturn endpoints that were
+		// previously in the pool but are no longer being returned by the orchestrator. It's highly
+		// likely that the Orchestrator has deemed them to be non-functional/malicious.
+		// Let's just override the old pool with the new endpoints returned here.
 		oldMap := make(map[string]bool)
 		n := make([]*Member, 0, len(newEP))
 		for _, o := range p.endpoints {
 			oldMap[o.String()] = true
 			n = append(n, o)
 		}
+
 		p.lk.RUnlock()
 
 		for _, s := range newEP {
@@ -136,7 +153,6 @@ func (p *pool) doRefresh() {
 	} else {
 		poolErrorMetric.Add(1)
 	}
-
 }
 
 func (p *pool) refreshPool() {
@@ -177,10 +193,10 @@ func (p *pool) Close() {
 }
 
 func (p *pool) fetchWith(ctx context.Context, c cid.Cid, with string) (blk blocks.Block, err error) {
+	// wait for pool to be initialised
 	<-p.started
 
-	left := p.config.MaxRetries
-
+	left := p.config.MaxRetrievalAttempts
 	aff := with
 	if aff == "" {
 		aff = c.Hash().B58String()
@@ -190,12 +206,16 @@ func (p *pool) fetchWith(ctx context.Context, c cid.Cid, with string) (blk block
 	if left > len(p.endpoints) {
 		left = len(p.endpoints)
 	}
+
+	// if there are no endpoints in the consistent hashing ring, we submit a pool refresh request and fail this fetch.
 	if p.c == nil || p.c.Size() == 0 {
 		p.lk.RUnlock()
 		return nil, ErrNoBackend
 	}
 	nodes, ok := p.c.GetNodes(aff, left)
 	p.lk.RUnlock()
+
+	// if there are no endpoints in the consistent hashing ring for the given cid, we submit a pool refresh request and fail this fetch.
 	if !ok || len(nodes) == 0 {
 		select {
 		case p.refresh <- struct{}{}:
@@ -207,51 +227,72 @@ func (p *pool) fetchWith(ctx context.Context, c cid.Cid, with string) (blk block
 
 	for i := 0; i < len(nodes); i++ {
 		blk, err = p.doFetch(ctx, nodes[i], c)
-		if err != nil {
-			p.lk.RLock()
-			idx := -1
-			var nm *Member
-			var needUpdate bool
-			for j, m := range p.endpoints {
-				if m.String() == nodes[i] {
-					if nm, needUpdate = m.Downvote(p.config.PoolFailureDownvoteDebounce); needUpdate {
-						idx = j
-					}
-					break
-				}
-			}
-			p.lk.RUnlock()
-			if idx != -1 {
-				p.lk.Lock()
-				if p.endpoints[idx].string == nm.string {
-					if nm.replication == 0 {
-						p.c = p.c.RemoveNode(nm.string)
-						p.endpoints = append(p.endpoints[:idx], p.endpoints[idx+1:]...)
-						if len(p.endpoints) < p.config.PoolLowWatermark {
-							select {
-							case p.refresh <- struct{}{}:
-							default:
-							}
-						}
-					} else {
-						p.endpoints[idx] = nm
-						p.c.UpdateWithWeights(p.endpoints.ToWeights())
-					}
-				}
-				p.lk.Unlock()
-			}
+		// Saturn fetch was successful, we can return the block.
+		if err == nil {
+			return
+		}
+
+		// Saturn fetch failed, we downvote the failing member and try the next one.
+		p.lk.RLock()
+		idx, nm := p.downVoteMemberUnlocked(nodes[i])
+		p.lk.RUnlock()
+
+		// we weren't able to downvote the failing Saturn node, let's just retry the fetch with a new node.
+		if idx == -1 || nm == nil {
 			continue
 		}
 
-		return
+		// we need to take the lock as we're updating the list of pool endpoint members below.
+		p.lk.Lock()
+		if p.endpoints[idx].url == nm.url {
+			// if the failing member has been downvoted to 0, we remove it from the pool.
+			// if after removing this member from the pool, the size of the pool falls below the low watermark,
+			// we attempt a pool refresh.
+			if nm.replication == 0 {
+				p.c = p.c.RemoveNode(nm.url)
+				p.endpoints = append(p.endpoints[:idx], p.endpoints[idx+1:]...)
+				if len(p.endpoints) < p.config.PoolLowWatermark {
+					select {
+					case p.refresh <- struct{}{}:
+					default:
+					}
+				}
+			} else {
+				// if the failing member has been downvotes but not to 0, simply update the new weight
+				// in the pool.
+				p.endpoints[idx] = nm
+				p.c.UpdateWithWeights(p.endpoints.ToWeights())
+			}
+		}
+		p.lk.Unlock()
 	}
+
+	// Saturn fetch failed after exhausting all retrieval attempts, we can return the error.
 	return
 }
 
-var tmpl = "http://%s/ipfs/%s?format=raw"
+func (p *pool) downVoteMemberUnlocked(node string) (index int, member *Member) {
+	idx := -1
+	var nm *Member
+	var needUpdate bool
+	for j, m := range p.endpoints {
+		if m.String() == node {
+			if nm, needUpdate = m.Downvote(p.config.PoolFailureDownvoteDebounce); needUpdate {
+				idx = j
+			}
+			break
+		}
+	}
 
+	return idx, nm
+}
+
+var saturnReqTmpl = "http://%s/ipfs/%s?format=raw"
+
+// doFetch attempts to fetch a block from a given Saturn endpoint. It sends the retrieval logs to the logging endpoint upon a successful or failed attempt.
 func (p *pool) doFetch(ctx context.Context, from string, c cid.Cid) (b blocks.Block, e error) {
-	goLogger.Debugw("doing fetch", "from", from, "of", c)
+	requestId := uuid.NewString()
+	goLogger.Debugw("doing fetch", "from", from, "of", c, "requestId", requestId)
 	start := time.Now()
 	fb := time.Now()
 	code := 0
@@ -268,12 +309,12 @@ func (p *pool) doFetch(ctx context.Context, from string, c cid.Cid) (b blocks.Bl
 		}
 		p.logger.queue <- log{
 			CacheHit:  false,
-			URL:       "",
+			URL:       from,
 			LocalTime: start,
 			// TODO: does this include header sizes?
 			NumBytesSent:    received,
 			RequestDuration: time.Since(start).Seconds(),
-			RequestID:       uuid.NewString(),
+			RequestID:       requestId,
 			HTTPStatusCode:  code,
 			HTTPProtocol:    proto,
 			TTFBMS:          int(fb.Sub(start).Milliseconds()),
@@ -284,7 +325,7 @@ func (p *pool) doFetch(ctx context.Context, from string, c cid.Cid) (b blocks.Bl
 			UserAgent:     respReq.UserAgent(),
 		}
 	}()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf(tmpl, from, c), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf(saturnReqTmpl, from, c), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -298,15 +339,18 @@ func (p *pool) doFetch(ctx context.Context, from string, c cid.Cid) (b blocks.Bl
 		}
 	}
 
-	resp, err := p.config.Client.Do(req)
+	resp, err := p.config.SaturnClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	fb = time.Now()
 	code = resp.StatusCode
 	proto = resp.Proto
 	respReq = resp.Request
-	defer resp.Body.Close()
+
+	// TODO: What if the Saturn node is malicious ? We should have an upper bound on how many bytes we read here.
 	rb, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/pool.go
+++ b/pool.go
@@ -373,15 +373,14 @@ func (p *pool) doFetch(ctx context.Context, from string, c cid.Cid) (b blocks.Bl
 	}
 
 	resp, err := p.config.SaturnClient.Do(req)
+	fb = time.Now()
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	fb = time.Now()
 	if resp.StatusCode != http.StatusOK {
 		return nil, ErrBackendFailed
 	}
-
 
 	code = resp.StatusCode
 	proto = resp.Proto

--- a/pool.go
+++ b/pool.go
@@ -377,11 +377,12 @@ func (p *pool) doFetch(ctx context.Context, from string, c cid.Cid) (b blocks.Bl
 		return nil, err
 	}
 	defer resp.Body.Close()
+	fb = time.Now()
 	if resp.StatusCode != http.StatusOK {
 		return nil, ErrBackendFailed
 	}
 
-	fb = time.Now()
+
 	code = resp.StatusCode
 	proto = resp.Proto
 	respReq = resp.Request

--- a/pool.go
+++ b/pool.go
@@ -325,7 +325,10 @@ func (p *pool) doFetch(ctx context.Context, from string, c cid.Cid) (b blocks.Bl
 			UserAgent:     respReq.UserAgent(),
 		}
 	}()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf(saturnReqTmpl, from, c), nil)
+
+	reqCtx, cancel := context.WithTimeout(ctx, DefaultSaturnRequestTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, fmt.Sprintf(saturnReqTmpl, from, c), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR aims to land https://github.com/filecoin-saturn/caboose/pull/19 and make some changes on top of it. 

The main changes include:

- Take care of `slowly re-fill the reputation of down-weighted backends as they successfully return content` TODO in https://github.com/filecoin-saturn/caboose/pull/19. The way we do this is by bumping up the weights of downvoted nodes that successfully return content by 20 percent on every success with a debounce until they hit the default weight of 20 that we assign to all nodes.

- Addresses @lidel 's comment at https://github.com/filecoin-saturn/caboose/pull/19#discussion_r1105843807 by ensuring we timeout requests to the Saturn L1s with a reasonable default.

- I want to make some changes around how we refresh the pool after getting back a list of Saturn nodes from the Orchestrator and how we read the blocks in memory. Please take a look at https://github.com/filecoin-saturn/caboose/pull/26#discussion_r1107077024 and https://github.com/filecoin-saturn/caboose/pull/26#discussion_r1107080733 and let me know what you think.

- I think I found and fixed a bug around how we were updating the weights. Please see  https://github.com/filecoin-saturn/caboose/pull/26#discussion_r1107075422

- Some refactoring to remove boilerplate and added documentation for people to grok what's happening in the code.

- I'll add some comprehensive unit tests in follow up PRs as there's a lot of code here that needs testing.

Closes #27 Closes #25