### PR TITLE
Refactor locks to event loop and feed Saturn HTTP status codes into the weights

### DIFF
--- a/caboose.go
+++ b/caboose.go
@@ -58,6 +58,9 @@ var ErrNotImplemented error = errors.New("not implemented")
 var ErrNoBackend error = errors.New("no available strn backend")
 var ErrBackendFailed error = errors.New("strn backend failed")
 
+// ErrTransient is returned when a transient error(timeouts, not found etc) occurs while fetching from the strn backend.
+var ErrTransient error = errors.New("transient error while fetching from strn backend")
+
 type Caboose struct {
 	config *Config
 	pool   *pool

--- a/caboose.go
+++ b/caboose.go
@@ -48,7 +48,7 @@ type Config struct {
 }
 
 const DefaultMaxRetries = 3
-const DefaultPoolFailureDownvoteDebounce = time.Second
+const DefaultPoolFailureDownvoteDebounce = 2 * time.Second
 const DefaultPoolLowWatermark = 5
 const DefaultSaturnRequestTimeout = 19 * time.Second
 const maxBlockSize = 4194305 // 4 Mib + 1 byte

--- a/failure_test.go
+++ b/failure_test.go
@@ -58,7 +58,7 @@ func TestCabooseFailures(t *testing.T) {
 		DoValidation:             false,
 		PoolWeightChangeDebounce: time.Duration(1),
 		PoolRefresh:              time.Millisecond * 50,
-		MaxRetrievalAttempts:     2,
+		MaxRetrievalAttempts:     3,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/ipld/go-ipld-prime v0.19.0
 	github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20230102063945-1a409dc236dd
 	github.com/multiformats/go-multicodec v0.7.0
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.14.0
 	github.com/serialx/hashring v0.0.0-20200727003509-22c0c7ab6b1b
 	github.com/urfave/cli/v2 v2.24.2

--- a/go.sum
+++ b/go.sum
@@ -331,6 +331,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9 h1:1/WtZae0yGtPq+TI6+Tv1WTxkukpXeMlviSxvL7SRgk=
 github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9/go.mod h1:x3N5drFsm2uilKKuuYo6LdyD8vZAW55sH/9w+pbo1sw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pool.go
+++ b/pool.go
@@ -304,6 +304,8 @@ func (p *pool) ringLoop() {
 				for _, n := range nodes {
 					downVote(n, 20)
 				}
+
+				// remove this key from the cache so we don't penalise the same nodes again for failing to fetch this content.
 				transientErrorsCache.Delete(key)
 			}
 

--- a/pool.go
+++ b/pool.go
@@ -302,7 +302,7 @@ func (p *pool) ringLoop() {
 			if ok {
 				nodes := vals.([]string)
 				for _, n := range nodes {
-					downVote(n, 20)
+					downVote(n, 50)
 				}
 
 				// remove this key from the cache so we don't penalise the same nodes again for failing to fetch this content.


### PR DESCRIPTION
The ring weights locking model was getting hard to reason about.
This PR refactors it to use an event loop instead.
Also, closes #https://github.com/filecoin-saturn/caboose/issues/28.