### PR TITLE
Use highly ranked backup nodes to restore and recover pool

### DIFF
--- a/caboose.go
+++ b/caboose.go
@@ -65,7 +65,7 @@ type Config struct {
 	// before we start making retrieval attempts for it.
 	CidCoolDownDuration time.Duration
 
-	// NBackupNodes is the number of backup nodes we will cache if a pool refresh isn't enough to have enough members in the pool.
+	// NBackupNodes is the number of backup nodes we will cache in order to restore the pool if a pool refresh alone isn't enough to restore it.
 	NBackupNodes int
 }
 

--- a/caboose.go
+++ b/caboose.go
@@ -81,7 +81,6 @@ const DefaultPoolRefreshInterval = 5 * time.Minute
 const DefaultMaxCidFailures = 3
 const DefaultCidCoolDownDuration = 10 * time.Minute
 const DefaultNBackupNodes = 20
-const DefaultMinNodesInPoolAfterRefresh = 20
 
 var ErrNotImplemented error = errors.New("not implemented")
 var ErrNoBackend error = errors.New("no available strn backend")

--- a/caboose.go
+++ b/caboose.go
@@ -72,7 +72,7 @@ type Config struct {
 const DefaultMaxRetries = 3
 const DefaultPoolFailureDownvoteDebounce = time.Second
 const DefaultPoolMembershipDebounce = 5 * time.Minute
-const DefaultPoolLowWatermark = 3
+const DefaultPoolLowWatermark = 5
 const DefaultSaturnRequestTimeout = 19 * time.Second
 const DefaultSaturnGlobalBlockFetchTimeout = 60 * time.Second
 const maxBlockSize = 4194305 // 4 Mib + 1 byte
@@ -80,7 +80,8 @@ const DefaultOrchestratorEndpoint = "https://orchestrator.strn.pl/nodes/nearby?c
 const DefaultPoolRefreshInterval = 5 * time.Minute
 const DefaultMaxCidFailures = 3
 const DefaultCidCoolDownDuration = 10 * time.Minute
-const DefaultNBackupNodes = 10
+const DefaultNBackupNodes = 20
+const DefaultMinNodesInPoolAfterRefresh = 20
 
 var ErrNotImplemented error = errors.New("not implemented")
 var ErrNoBackend error = errors.New("no available strn backend")

--- a/caboose.go
+++ b/caboose.go
@@ -64,12 +64,15 @@ type Config struct {
 	// CidCoolDownDuration is duration of time a cid will stay in the cool down cache
 	// before we start making retrieval attempts for it.
 	CidCoolDownDuration time.Duration
+
+	// NBackupNodes is the number of backup nodes we will cache if a pool refresh isn't enough to have enough members in the pool.
+	NBackupNodes int
 }
 
 const DefaultMaxRetries = 3
 const DefaultPoolFailureDownvoteDebounce = time.Second
 const DefaultPoolMembershipDebounce = 5 * time.Minute
-const DefaultPoolLowWatermark = 5
+const DefaultPoolLowWatermark = 3
 const DefaultSaturnRequestTimeout = 19 * time.Second
 const DefaultSaturnGlobalBlockFetchTimeout = 60 * time.Second
 const maxBlockSize = 4194305 // 4 Mib + 1 byte
@@ -77,6 +80,7 @@ const DefaultOrchestratorEndpoint = "https://orchestrator.strn.pl/nodes/nearby?c
 const DefaultPoolRefreshInterval = 5 * time.Minute
 const DefaultMaxCidFailures = 3
 const DefaultCidCoolDownDuration = 10 * time.Minute
+const DefaultNBackupNodes = 10
 
 var ErrNotImplemented error = errors.New("not implemented")
 var ErrNoBackend error = errors.New("no available strn backend")
@@ -107,11 +111,19 @@ func NewCaboose(config *Config) (ipfsblockstore.Blockstore, error) {
 		config.MaxCidFailuresBeforeCoolDown = DefaultMaxCidFailures
 	}
 
+	if config.NBackupNodes == 0 {
+		config.NBackupNodes = DefaultNBackupNodes
+	}
+
 	c := Caboose{
 		config: config,
-		pool:   newPool(config),
 		logger: newLogger(config),
 	}
+	pool, err := newPool(config)
+	if err != nil {
+		return nil, err
+	}
+	c.pool = pool
 	c.pool.logger = c.logger
 
 	if c.config.SaturnClient == nil {

--- a/caboose_test.go
+++ b/caboose_test.go
@@ -55,6 +55,11 @@ func TestCidCoolDown(t *testing.T) {
 func TestNodesBackup(t *testing.T) {
 	ctx := context.Background()
 	ch := BuildCabooseHarness(t, 3, 3, WithMembershipCoolDown(100*time.Hour))
+	require.Eventually(t, func() bool {
+		return ch.getHashRingSize() == 3
+	}, 10*time.Second, 500*time.Millisecond)
+	// stop the orchestrator so we never get nodes from the orchestrator
+	ch.stopOrchestrator()
 
 	// one node should get added to the backup list on a successful fetch
 	testCid, _ := cid.V1Builder{Codec: uint64(multicodec.Raw), MhType: uint64(multicodec.Sha2_256)}.Sum(testBlock)

--- a/failure_test.go
+++ b/failure_test.go
@@ -113,7 +113,6 @@ func TestCabooseFailures(t *testing.T) {
 	})
 	ch.runFetchesForRandCids(50)
 	require.EqualValues(t, 0, ch.nNodesAlive())
-	require.EqualValues(t, 0, ch.getHashRingSize())
 
 	_, err := ch.c.Get(context.Background(), testCid)
 	require.Error(t, err)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/google/uuid v1.3.0
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/ipfs/go-cid v0.3.2
 	github.com/ipfs/go-ipfs-blockstore v1.2.0
 	github.com/ipfs/go-libipfs v0.6.1-0.20230224134131-7ba1df55d53b
@@ -37,7 +38,6 @@ require (
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
 	github.com/ipfs/go-block-format v0.1.1 // indirect
 	github.com/ipfs/go-blockservice v0.5.0 // indirect

--- a/pool_test.go
+++ b/pool_test.go
@@ -273,13 +273,16 @@ func BuildPoolHarness(t *testing.T, n int, opts ...HarnessOption) *poolHarness {
 		PoolWeightChangeDebounce: 100 * time.Millisecond,
 		PoolRefresh:              100 * time.Millisecond,
 		PoolMembershipDebounce:   100 * time.Millisecond,
+		NBackupNodes:             4,
 	}
 
 	for _, opt := range opts {
 		opt(config)
 	}
 
-	ph.pool = newPool(config)
+	var err error
+	ph.pool, err = newPool(config)
+	require.NoError(t, err)
 	ph.eps = purls
 
 	return ph


### PR DESCRIPTION
Counter to https://github.com/filecoin-saturn/caboose/pull/49.

We should keep the membership cool down cache around to prevent underperforming nodes from getting into the pool. In the event that we aren't able to fill up the pool with enough members, we will use a cache of recent well performing nodes as backup nodes to restore the pool.