### PR TITLE
Better downvoting and cool down fetches

### DIFF
--- a/caboose.go
+++ b/caboose.go
@@ -65,7 +65,7 @@ type Config struct {
 
 const DefaultMaxRetries = 3
 const DefaultPoolFailureDownvoteDebounce = 30 * time.Second
-const DefaultPoolMembershipDebounce = 5 * time.Minute
+const DefaultPoolMembershipDebounce = 10 * time.Minute
 const DefaultPoolLowWatermark = 5
 const DefaultSaturnRequestTimeout = 19 * time.Second
 const maxBlockSize = 4194305 // 4 Mib + 1 byte

--- a/caboose.go
+++ b/caboose.go
@@ -68,6 +68,8 @@ type Config struct {
 	// SaturnNodeCoolOff is the cool off duration for a saturn node once we determine that we shouldn't be sending requests to it for a while.
 	SaturnNodeCoolOff time.Duration
 
+	MinCoolOff time.Duration
+
 	// MaxNCoolOff is the number of times we will cool off a node before downvoting it.
 	MaxNCoolOff int
 }
@@ -140,6 +142,9 @@ func NewCaboose(config *Config) (ipfsblockstore.Blockstore, error) {
 
 	if config.SaturnNodeCoolOff == 0 {
 		config.SaturnNodeCoolOff = DefaultSaturnNodeCoolOff
+	}
+	if config.MinCoolOff == 0 {
+		config.MinCoolOff = 1 * time.Minute
 	}
 
 	if config.MaxNCoolOff == 0 {

--- a/caboose.go
+++ b/caboose.go
@@ -56,11 +56,11 @@ type Config struct {
 	// MaxRetrievalAttempts determines the number of times we will attempt to retrieve a block from the Saturn network before failing.
 	MaxRetrievalAttempts int
 
-	// SaturnNodeCoolOff is the cool of duration for a saturn node once we determine that we shouldn't be sending requests to it for a while
+	// SaturnNodeCoolOff is the cool off duration for a saturn node once we determine that we shouldn't be sending requests to it for a while.
 	SaturnNodeCoolOff time.Duration
 
-	// MaxCoolOffAttempts is the number of times we will cool off a node before downvoting it.
-	MaxCoolOffAttempts int
+	// MaxNCoolOff is the number of times we will cool off a node before downvoting it.
+	MaxNCoolOff int
 }
 
 const DefaultMaxRetries = 3
@@ -72,7 +72,7 @@ const maxBlockSize = 4194305 // 4 Mib + 1 byte
 const DefaultOrchestratorEndpoint = "https://orchestrator.strn.pl/nodes/nearby?count=1000"
 const DefaultPoolRefreshInterval = 5 * time.Minute
 const DefaultSaturnNodeCoolOff = 5 * time.Minute
-const DefaultMaxCoolOffAttempts = 3
+const DefaultMaxNCoolOff = 3
 
 var ErrNotImplemented error = errors.New("not implemented")
 var ErrNoBackend error = errors.New("no available strn backend")
@@ -92,8 +92,8 @@ func NewCaboose(config *Config) (ipfsblockstore.Blockstore, error) {
 		config.SaturnNodeCoolOff = DefaultSaturnNodeCoolOff
 	}
 
-	if config.MaxCoolOffAttempts == 0 {
-		config.MaxCoolOffAttempts = DefaultMaxCoolOffAttempts
+	if config.MaxNCoolOff == 0 {
+		config.MaxNCoolOff = DefaultMaxNCoolOff
 	}
 
 	c := Caboose{

--- a/caboose.go
+++ b/caboose.go
@@ -61,11 +61,10 @@ type Config struct {
 }
 
 const DefaultMaxRetries = 3
-const DefaultPoolFailureDownvoteDebounce = time.Second
+const DefaultPoolFailureDownvoteDebounce = 30 * time.Second
 const DefaultPoolMembershipDebounce = 5 * time.Minute
 const DefaultPoolLowWatermark = 5
 const DefaultSaturnRequestTimeout = 19 * time.Second
-const DefaultSaturnGlobalBlockFetchTimeout = 60 * time.Second
 const maxBlockSize = 4194305 // 4 Mib + 1 byte
 const DefaultOrchestratorEndpoint = "https://orchestrator.strn.pl/nodes/nearby?count=1000"
 const DefaultPoolRefreshInterval = 5 * time.Minute

--- a/caboose.go
+++ b/caboose.go
@@ -73,16 +73,21 @@ type Config struct {
 }
 
 const DefaultMaxRetries = 3
-const DefaultPoolFailureDownvoteDebounce = 30 * time.Second
-const DefaultPoolMembershipDebounce = 10 * time.Minute
+const DefaultPoolFailureDownvoteDebounce = 1 * time.Minute
+const DefaultPoolMembershipDebounce = 3 * DefaultPoolRefreshInterval
 const DefaultPoolLowWatermark = 5
 const DefaultSaturnRequestTimeout = 19 * time.Second
 const maxBlockSize = 4194305 // 4 Mib + 1 byte
 const DefaultOrchestratorEndpoint = "https://orchestrator.strn.pl/nodes/nearby?count=1000"
 const DefaultPoolRefreshInterval = 5 * time.Minute
 
+// we cool off sending requests to Saturn for a cid for a certain duration
+// if we've seen a certain number of failures for it already in a given duration.
 const DefaultMaxCidFailures = 3
-const DefaultCidCoolDownDuration = 10 * time.Minute
+const DefaultCidCoolDownDuration = 5 * time.Minute
+
+// we cool off sending requests to a Saturn node if it returns transient errors rather than immediately downvoting it;
+// however, only upto a certain max number of cool-offs.
 const DefaultSaturnNodeCoolOff = 5 * time.Minute
 const DefaultMaxNCoolOff = 3
 

--- a/caboose.go
+++ b/caboose.go
@@ -96,7 +96,15 @@ var ErrNoBackend error = errors.New("no available strn backend")
 var ErrBackendFailed error = errors.New("strn backend failed")
 var ErrContentProviderNotFound error = errors.New("strn failed to find content providers")
 var ErrSaturnTimeout error = errors.New("strn backend timed out")
-var ErrSaturnTooManyRequests error = errors.New("strn backend returned `too many requests` error; 429")
+
+type ErrSaturnTooManyRequests struct {
+	Node         string
+	RetryAfterMs int64
+}
+
+func (e ErrSaturnTooManyRequests) Error() string {
+	return fmt.Sprintf("saturn node %s returned `too many requests` error, please retry after %d milliseconds", e.Node, e.RetryAfterMs)
+}
 
 type ErrCidCoolDown struct {
 	Cid          cid.Cid

--- a/caboose.go
+++ b/caboose.go
@@ -56,8 +56,11 @@ type Config struct {
 	// MaxRetrievalAttempts determines the number of times we will attempt to retrieve a block from the Saturn network before failing.
 	MaxRetrievalAttempts int
 
-	// TooManyReqsCoolOff is the cool of duration for a saturn node once it returns a 429
-	TooManyReqsCoolOff time.Duration
+	// SaturnNodeCoolOff is the cool of duration for a saturn node once we determine that we shouldn't be sending requests to it for a while
+	SaturnNodeCoolOff time.Duration
+
+	// MaxCoolOffAttempts is the number of times we will cool off a node before downvoting it.
+	MaxCoolOffAttempts int
 }
 
 const DefaultMaxRetries = 3
@@ -68,15 +71,15 @@ const DefaultSaturnRequestTimeout = 19 * time.Second
 const maxBlockSize = 4194305 // 4 Mib + 1 byte
 const DefaultOrchestratorEndpoint = "https://orchestrator.strn.pl/nodes/nearby?count=1000"
 const DefaultPoolRefreshInterval = 5 * time.Minute
-const DefaultTooManyReqsCoolOff = 5 * time.Minute
-const MaxNCoolOff = 3
+const DefaultSaturnNodeCoolOff = 5 * time.Minute
+const DefaultMaxCoolOffAttempts = 3
 
 var ErrNotImplemented error = errors.New("not implemented")
 var ErrNoBackend error = errors.New("no available strn backend")
 var ErrBackendFailed error = errors.New("strn backend failed")
 var ErrContentProviderNotFound error = errors.New("strn failed to find content providers")
 var ErrSaturnTimeout error = errors.New("strn backend timed out")
-var ErrSaturnTooManyRequests error = errors.New("strn backend returned too many requests error; 429")
+var ErrSaturnTooManyRequests error = errors.New("strn backend returned `too many requests` error; 429")
 
 type Caboose struct {
 	config *Config
@@ -85,9 +88,14 @@ type Caboose struct {
 }
 
 func NewCaboose(config *Config) (ipfsblockstore.Blockstore, error) {
-	if config.TooManyReqsCoolOff == 0 {
-		config.TooManyReqsCoolOff = DefaultTooManyReqsCoolOff
+	if config.SaturnNodeCoolOff == 0 {
+		config.SaturnNodeCoolOff = DefaultSaturnNodeCoolOff
 	}
+
+	if config.MaxCoolOffAttempts == 0 {
+		config.MaxCoolOffAttempts = DefaultMaxCoolOffAttempts
+	}
+
 	c := Caboose{
 		config: config,
 		pool:   newPool(config),

--- a/caboose.go
+++ b/caboose.go
@@ -92,10 +92,10 @@ const DefaultSaturnNodeCoolOff = 5 * time.Minute
 const DefaultMaxNCoolOff = 3
 
 var ErrNotImplemented error = errors.New("not implemented")
-var ErrNoBackend error = errors.New("no available strn backend")
-var ErrBackendFailed error = errors.New("strn backend failed")
-var ErrContentProviderNotFound error = errors.New("strn failed to find content providers")
-var ErrSaturnTimeout error = errors.New("strn backend timed out")
+var ErrNoBackend error = errors.New("no available saturn backend")
+var ErrBackendFailed error = errors.New("saturn backend failed")
+var ErrContentProviderNotFound error = errors.New("saturn failed to find content providers")
+var ErrSaturnTimeout error = errors.New("saturn backend timed out")
 
 type ErrSaturnTooManyRequests struct {
 	Node         string
@@ -112,7 +112,7 @@ type ErrCidCoolDown struct {
 }
 
 func (e *ErrCidCoolDown) Error() string {
-	return fmt.Sprintf("multiple retrieval failures seen for cid %s, please retry after %d milliseconds", e.Cid, e.RetryAfterMs)
+	return fmt.Sprintf("multiple saturn retrieval failures seen for CID %s, please retry after %d milliseconds", e.Cid, e.RetryAfterMs)
 }
 
 type Caboose struct {

--- a/caboose_test.go
+++ b/caboose_test.go
@@ -54,6 +54,12 @@ func TestCidCoolDown(t *testing.T) {
 
 type HarnessOption func(config *caboose.Config)
 
+func WithPoolMembershipDebounce(d time.Duration) func(config *caboose.Config) {
+	return func(config *caboose.Config) {
+		config.PoolMembershipDebounce = d
+	}
+}
+
 func WithMaxCidFailuresBeforeCoolDown(max int) func(config *caboose.Config) {
 	return func(config *caboose.Config) {
 		config.MaxCidFailuresBeforeCoolDown = max
@@ -63,6 +69,12 @@ func WithMaxCidFailuresBeforeCoolDown(max int) func(config *caboose.Config) {
 func WithCidCoolDownDuration(duration time.Duration) func(config *caboose.Config) {
 	return func(config *caboose.Config) {
 		config.CidCoolDownDuration = duration
+	}
+}
+
+func WithMaxNCoolOff(n int) func(config *caboose.Config) {
+	return func(config *caboose.Config) {
+		config.MaxNCoolOff = n
 	}
 }
 

--- a/caboose_test.go
+++ b/caboose_test.go
@@ -25,9 +25,9 @@ func TestCidCoolDown(t *testing.T) {
 	ch.fetchAndAssertSuccess(t, ctx, testCid)
 
 	// Invalidate all servers so we cool down cids
-	ch.failNodes(t, func(e *ep) bool {
+	ch.failNodesWithCode(t, func(e *ep) bool {
 		return true
-	})
+	}, 503)
 
 	// Fetch should fail with fetch error
 	ch.fetchAndAssertFailure(t, ctx, testCid, "503")

--- a/failure_test.go
+++ b/failure_test.go
@@ -72,11 +72,6 @@ func TestCabooseTransientFailures(t *testing.T) {
 		nodeWeight = (nodeWeight * 80) / 100
 		_, err = ch.c.Get(ctx, randCid)
 		require.Contains(t, err.Error(), "504")
-		weights = ch.getPoolWeights()
-		require.Len(t, weights, 3)
-		for _, w := range weights {
-			require.EqualValues(t, nodeWeight, w)
-		}
 		if nodeWeight == 1 {
 			break
 		}

--- a/failure_test.go
+++ b/failure_test.go
@@ -264,6 +264,9 @@ func (e *ep) Setup() {
 			if e.httpCode == http.StatusTooManyRequests {
 				w.Header().Set("Retry-After", "1")
 			}
+			if e.httpCode == 0 {
+				e.httpCode = 500
+			}
 			w.WriteHeader(e.httpCode)
 			w.Write([]byte("error"))
 		}

--- a/failure_test.go
+++ b/failure_test.go
@@ -163,15 +163,6 @@ func (ch *CabooseHarness) fetchAndAssertSuccess(t *testing.T, ctx context.Contex
 	require.NotEmpty(t, blk)
 }
 
-func (ch *CabooseHarness) failNodesWith429(t *testing.T, selectorF func(ep *ep) bool) {
-	for _, n := range ch.pool {
-		if selectorF(n) {
-			n.valid = false
-			n.tooManyReqsErr = true
-		}
-	}
-}
-
 func (ch *CabooseHarness) failNodesWithTransientErr(t *testing.T, selectorF func(ep *ep) bool) {
 	for _, n := range ch.pool {
 		if selectorF(n) {

--- a/failure_test.go
+++ b/failure_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var maxCabooseWeight = 20
-var retryAfterMs = 1000
+var expRetryAfter = 1 * time.Second
 
 func TestHttp429(t *testing.T) {
 	ctx := context.Background()
@@ -31,7 +31,7 @@ func TestHttp429(t *testing.T) {
 	require.Error(t, err)
 
 	ferr := err.(*caboose.ErrSaturnTooManyRequests)
-	require.EqualValues(t, retryAfterMs, ferr.RetryAfterMs)
+	require.EqualValues(t, expRetryAfter, ferr.RetryAfter)
 }
 
 func TestCabooseTransientFailures(t *testing.T) {
@@ -165,7 +165,7 @@ func (ch *CabooseHarness) fetchAndAssertCoolDownError(t *testing.T, ctx context.
 	coolDownErr, ok := err.(*caboose.ErrCidCoolDown)
 	require.True(t, ok)
 	require.EqualValues(t, cid, coolDownErr.Cid)
-	require.NotZero(t, coolDownErr.RetryAfterMs)
+	require.NotZero(t, coolDownErr.RetryAfter)
 }
 
 func (ch *CabooseHarness) fetchAndAssertFailure(t *testing.T, ctx context.Context, testCid cid.Cid, contains string) {

--- a/pool.go
+++ b/pool.go
@@ -13,11 +13,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/patrickmn/go-cache"
-
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
 	blocks "github.com/ipfs/go-libipfs/blocks"
+	"github.com/patrickmn/go-cache"
 	"github.com/serialx/hashring"
 )
 
@@ -299,7 +298,7 @@ func (p *pool) fetchWith(ctx context.Context, c cid.Cid, with string) (blk block
 
 	coolOffTransientsF := func() {
 		reqs := make([]weightUpdateReq, 0, len(transientErrs))
-		for node, _ := range transientErrs {
+		for node := range transientErrs {
 			reqs = append(reqs, weightUpdateReq{
 				node:    node,
 				failure: true,

--- a/pool.go
+++ b/pool.go
@@ -180,7 +180,6 @@ func (p *pool) doRefresh() {
 			newNodeWeight = 1
 		}
 		if len(p.endpoints) == 0 {
-			goLogger.Errorw("POOL 0")
 			newNodeWeight = maxWeight
 			removedNodeWeight = maxWeight
 		}

--- a/pool.go
+++ b/pool.go
@@ -169,6 +169,7 @@ func (p *pool) doRefresh() {
 			// add back node with lower weight if it was removed recently.
 			if _, ok := p.removedTimeCache.Get(s); ok {
 				if _, ok := oldMap[s]; !ok {
+					p.removedTimeCache.Delete(s)
 					n = append(n, NewMemberWithWeight(s, defaultReplication/2, time.Time{}))
 					continue
 				}

--- a/pool.go
+++ b/pool.go
@@ -483,11 +483,12 @@ func (p *pool) isCoolOffLocked(node string) bool {
 
 	// reduce cool off duration if we've repeatedly seen a cool off request for this node.
 	newCoolOffMs := p.config.SaturnNodeCoolOff.Milliseconds() / int64(oldVal+1)
-	if newCoolOffMs == 0 {
-		newCoolOffMs = 1
+	minCoolOff := time.Duration(newCoolOffMs) * time.Millisecond
+	if minCoolOff == 0 {
+		minCoolOff = p.config.MinCoolOff
 	}
 
-	p.coolOffCache.Set(node, struct{}{}, time.Duration(newCoolOffMs)*time.Millisecond)
+	p.coolOffCache.Set(node, struct{}{}, minCoolOff)
 
 	return (oldVal + 1) <= p.config.MaxNCoolOff
 }

--- a/pool.go
+++ b/pool.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -70,7 +71,7 @@ type MemberList []*Member
 func (m MemberList) ToWeights() map[string]int {
 	ml := make(map[string]int, len(m))
 	for _, mm := range m {
-		ml[mm.url] = mm.replication
+		ml[mm.url] = mm.weight
 	}
 	return ml
 }
@@ -79,19 +80,16 @@ func (m MemberList) ToWeights() map[string]int {
 type Member struct {
 	lk sync.Mutex
 
-	url         string
-	lastUpdate  time.Time
-	replication int
+	addedAt    time.Time
+	url        string
+	lastUpdate time.Time
+	weight     int
 }
 
-var defaultReplication = 20
+var maxWeight = 20
 
-func NewMemberWithWeight(addr string, weight int, lastUpdateTime time.Time) *Member {
-	return &Member{url: addr, lk: sync.Mutex{}, lastUpdate: lastUpdateTime, replication: weight}
-}
-
-func NewMember(addr string, lastUpdateTime time.Time) *Member {
-	return &Member{url: addr, lk: sync.Mutex{}, lastUpdate: lastUpdateTime, replication: defaultReplication}
+func NewMemberWithWeight(addr string, weight int, addedAt time.Time, lastUpdateTime time.Time) *Member {
+	return &Member{url: addr, lk: sync.Mutex{}, lastUpdate: lastUpdateTime, weight: weight, addedAt: addedAt}
 }
 
 func (m *Member) String() string {
@@ -99,33 +97,33 @@ func (m *Member) String() string {
 }
 
 func (m *Member) ReplicationFactor() int {
-	return m.replication
+	return m.weight
 }
 
 func (m *Member) UpdateWeight(debounce time.Duration, failure bool) (*Member, bool) {
 	// this is a best-effort. if there's a correlated failure we ignore the others, so do the try on best-effort.
 	if m.lk.TryLock() {
 		defer m.lk.Unlock()
+
 		if debounce == 0 || time.Since(m.lastUpdate) > debounce {
 			// make the down-voted member
-			nm := NewMember(m.url, time.Now())
 			if failure {
 				// reduce weight by 20%
-				nm.replication = (m.replication * 80) / 100
+				nm := NewMemberWithWeight(m.url, (m.weight*80)/100, m.addedAt, time.Now())
 				return nm, true
-			} else {
-				if m.replication < defaultReplication {
-					updated := m.replication + 1
-					if updated > defaultReplication {
-						updated = defaultReplication
-					}
-					if updated != m.replication {
-						nm.replication = updated
-						return nm, true
-					}
+			}
+
+			if m.weight < maxWeight {
+				updated := m.weight + 1
+				if updated > maxWeight {
+					updated = maxWeight
+				}
+				if updated != m.weight {
+					nm := NewMemberWithWeight(m.url, updated, m.addedAt, time.Now())
+					return nm, true
 				}
 			}
-			return nm, false
+
 		}
 	}
 	return nil, false
@@ -173,20 +171,45 @@ func (p *pool) doRefresh() {
 			n = append(n, o)
 		}
 
+		removedNodeWeight := (maxWeight * 10) / 100
+		if removedNodeWeight == 0 {
+			removedNodeWeight = 1
+		}
+		newNodeWeight := (maxWeight * 30) / 100
+		if newNodeWeight == 0 {
+			newNodeWeight = 1
+		}
+		if len(p.endpoints) == 0 {
+			goLogger.Errorw("POOL 0")
+			newNodeWeight = maxWeight
+			removedNodeWeight = maxWeight
+		}
+
 		for _, s := range newEP {
 			// add back node with lower weight if it was removed recently.
 			if _, ok := p.removedTimeCache.Get(s); ok {
 				if _, ok := oldMap[s]; !ok {
 					p.removedTimeCache.Delete(s)
-					n = append(n, NewMemberWithWeight(s, defaultReplication/2, time.Time{}))
+					n = append(n, NewMemberWithWeight(s, removedNodeWeight, time.Now(), time.Time{}))
 					continue
 				}
 			}
 
 			if _, ok := oldMap[s]; !ok {
 				// we set last update time to zero so we do NOT hit debounce limits for this node immediately on creation.
-				n = append(n, NewMember(s, time.Time{}))
+				// start with a low weight as this is an unproven node and increase over time.
+				n = append(n, NewMemberWithWeight(s, newNodeWeight, time.Now(), time.Time{}))
 			}
+		}
+
+		// If we have more than 200 nodes, pick the top 200 sorted by (weight * age).
+		if len(n) > 200 {
+			sort.Slice(n, func(i, j int) bool {
+				return int64(int64(n[i].weight)*n[i].addedAt.Unix()) > int64(int64(n[j].weight)*n[j].addedAt.Unix())
+			})
+			n = n[:200]
+			goLogger.Infow("trimmed pool list to 200", "first", n[0].url, "first_weight",
+				n[0].weight, "last", n[199].url, "last_weight", n[199].weight)
 		}
 
 		p.endpoints = n
@@ -200,10 +223,10 @@ func (p *pool) doRefresh() {
 		// periodic update of a pool health metric
 		byWeight := make(map[int]int)
 		for _, m := range p.endpoints {
-			if _, ok := byWeight[m.replication]; !ok {
-				byWeight[m.replication] = 0
+			if _, ok := byWeight[m.weight]; !ok {
+				byWeight[m.weight] = 0
 			}
-			byWeight[m.replication] += 1
+			byWeight[m.weight] += 1
 		}
 		poolHealthMetric.Reset()
 		for weight, cnt := range byWeight {
@@ -275,6 +298,18 @@ func (p *pool) fetchWith(ctx context.Context, c cid.Cid, with string) (blk block
 		return nil, err
 	}
 
+	coolOffTransientsF := func() {
+		reqs := make([]weightUpdateReq, 0, len(transientErrs))
+		for node, _ := range transientErrs {
+			reqs = append(reqs, weightUpdateReq{
+				node:    node,
+				failure: true,
+				coolOff: true,
+			})
+		}
+		p.changeWeightBatched(reqs)
+	}
+
 	blockFetchStart := time.Now()
 	for i := 0; i < len(nodes); i++ {
 		blk, err = p.fetchAndUpdate(ctx, nodes[i], c, i, transientErrs)
@@ -284,19 +319,7 @@ func (p *pool) fetchWith(ctx context.Context, c cid.Cid, with string) (blk block
 			fetchSpeedPerBlockMetric.Observe(float64(float64(len(blk.RawData())) / float64(durationMs)))
 			fetchDurationBlockSuccessMetric.Observe(float64(durationMs))
 
-			// try and downvote nodes that returned transient errors because we got the content from elsewhere
-			// but only if they continue this behaviour even after a grace cool off period.
-			reqs := make([]weightUpdateReq, 0, len(transientErrs))
-			for node, err := range transientErrs {
-				goLogger.Debugw("downvoting node with transient err as fetch was subsequently successful", "node", node, "err", err)
-				reqs = append(reqs, weightUpdateReq{
-					node:    node,
-					failure: true,
-					coolOff: true,
-				})
-			}
-
-			p.changeWeightBatched(reqs)
+			coolOffTransientsF()
 			return
 		}
 	}
@@ -304,6 +327,9 @@ func (p *pool) fetchWith(ctx context.Context, c cid.Cid, with string) (blk block
 	fetchDurationBlockFailureMetric.Observe(float64(time.Since(blockFetchStart).Milliseconds()))
 
 	p.updateCidCoolDown(c)
+
+	// freeze transients
+	coolOffTransientsF()
 
 	// Saturn fetch failed after exhausting all retrieval attempts, we can return the error.
 	return
@@ -404,6 +430,7 @@ func (p *pool) getNodesToFetch(c cid.Cid, with string) ([]string, error) {
 	}
 
 	// if we still don't have enough nodes, just return the initial set of nodes we got without considering cool off.
+
 	return nodes, nil
 }
 
@@ -442,7 +469,7 @@ type weightUpdateReq struct {
 }
 
 func (p *pool) updatePoolWithNewWeightUnlocked(nm *Member, idx int) {
-	if nm.replication == 0 {
+	if nm.weight == 0 {
 		delete(p.coolOffCount, nm.url)
 		p.coolOffCache.Delete(nm.url)
 
@@ -463,10 +490,18 @@ func (p *pool) updatePoolWithNewWeightUnlocked(nm *Member, idx int) {
 }
 
 func (p *pool) isCoolOffUnlocked(node string) bool {
-	p.coolOffCache.Set(node, struct{}{}, cache.DefaultExpiration)
-	val := p.coolOffCount[node]
-	p.coolOffCount[node] = val + 1
-	return (val + 1) <= p.config.MaxNCoolOff
+	oldVal := p.coolOffCount[node]
+	p.coolOffCount[node] = oldVal + 1
+
+	// reduce cool off duration if we've repeatedly seen a cool off request for this node.
+	newCoolOffMs := p.config.SaturnNodeCoolOff.Milliseconds() / int64(oldVal+1)
+	if newCoolOffMs < (time.Minute.Milliseconds()) {
+		newCoolOffMs = time.Minute.Milliseconds()
+	}
+
+	p.coolOffCache.Set(node, struct{}{}, time.Duration(newCoolOffMs)*time.Millisecond)
+
+	return (oldVal + 1) <= p.config.MaxNCoolOff
 }
 
 // returns the updated weight mapping for tests

--- a/pool_test.go
+++ b/pool_test.go
@@ -178,7 +178,7 @@ func (ph *poolHarness) updateBatchedAndAssert(t *testing.T, reqs []batchUpdateRe
 		})
 	}
 
-	ph.pool.updateWeightBatched(weightReqs)
+	ph.pool.changeWeightBatched(weightReqs)
 
 	for _, req := range reqs {
 		ph.assertWeight(t, req.node, req.expected)

--- a/pool_test.go
+++ b/pool_test.go
@@ -211,7 +211,7 @@ func (ph *poolHarness) assertWeight(t *testing.T, url string, expected int) {
 
 	for i := range ph.pool.endpoints {
 		if ph.pool.endpoints[i].url == url {
-			require.EqualValues(t, expected, ph.pool.endpoints[i].replication)
+			require.EqualValues(t, expected, ph.pool.endpoints[i].weight)
 			return
 		}
 	}

--- a/pool_test.go
+++ b/pool_test.go
@@ -115,7 +115,7 @@ func TestUpdateWeightDebounce(t *testing.T) {
 
 func TestIsCoolOff(t *testing.T) {
 	dur := 50 * time.Millisecond
-	ph := BuildPoolHarness(t, 3, WithMaxNCoolOff(2), WithCoolOffDuration(dur))
+	ph := BuildPoolHarness(t, 3, WithMaxNCoolOff(2), WithCoolOffDuration(dur), WithMinCoolOff(1*time.Millisecond))
 	ph.StartAndWait(t)
 
 	require.True(t, ph.pool.isCoolOffLocked(ph.eps[0]))
@@ -215,6 +215,12 @@ type HarnessOption func(config *Config)
 func WithCoolOffDuration(dur time.Duration) func(*Config) {
 	return func(config *Config) {
 		config.SaturnNodeCoolOff = dur
+	}
+}
+
+func WithMinCoolOff(dur time.Duration) func(*Config) {
+	return func(config *Config) {
+		config.MinCoolOff = dur
 	}
 }
 


### PR DESCRIPTION
We need to downvote votes more gradually so that they get time to recover from temporary failures, Lassie timeouts, from being overloaded etc. but without them getting in the way of fetch requests However, once we remove a node from the pool post the gradual downvoting, we should make the node earn it's reputation back before we start sending more requests to it. To that end, this PR:

-  Introduces the concept of freezing/cooling down fetches from a node in the face of 429s/transient errors so nodes can get some time to recover instead of us trying them repeatedly and then downvoting them. However, there is a limit to how often we will cool down a node post which we will start downvoting/removing it.
- In my local testing using apache backend, I noticed that a number of Saturn Nodes returned 429s when we hammered them. This PR introduces cooling down of nodes that return 429s too.
- Instead of downvoting a node if it returns a transient error(when another node returns a success for the same fetch), we cool it down upto a certain number of attempts and give it time to recover from timeouts etc so that the downvoting is more gradual and nodes can stay around in our pool longer albeit in a frozen state so they don't hamper live requests.
- We downvote nodes by 20% instead of 50% to make the downvoting more gradual to not run into empty pools quickly.
- **_However_**,  once a node is removed from the pool, we will add it back with a much lower initial weight(50%) before it shows us some success and we start upvoting it.



### TODO
- [x] Solid Tests for fetch cool down
- [x] @guanzo to make L1 Nginx return a Retry duration.
- [x] @DiegoRBaquero to change Orchestrator to return nodes ranked by (weight + distance) (https://github.com/filecoin-saturn/orchestrator/issues/96).

### CURRENT Results from apache backend testing

```
 aarshshah@Aarshs-MacBook-Pro-2 caboose % ab -k -l -n 10000 -c 1000 -w "http://localhost:8081/ipns/en.wikipedia-on-ipfs.org/wiki/"
<p>
 This is ApacheBench, Version 2.3 <i>&lt;$Revision: 1879490 $&gt;</i><br>
 Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/<br>
 Licensed to The Apache Software Foundation, http://www.apache.org/<br>
</p>
<p>
Completed 1000 requests
Completed 2000 requests
Completed 3000 requests
Completed 4000 requests
Completed 5000 requests
Completed 6000 requests
Completed 7000 requests
Completed 8000 requests
Completed 9000 requests
Completed 10000 requests
Finished 10000 requests


<table >
<tr ><th colspan=2 bgcolor=white>Server Software:</th><td colspan=2 bgcolor=white></td></tr>
<tr ><th colspan=2 bgcolor=white>Server Hostname:</th><td colspan=2 bgcolor=white>localhost</td></tr>
<tr ><th colspan=2 bgcolor=white>Server Port:</th><td colspan=2 bgcolor=white>8081</td></tr>
<tr ><th colspan=2 bgcolor=white>Document Path:</th><td colspan=2 bgcolor=white>/ipns/en.wikipedia-on-ipfs.org/wiki/</td></tr>
<tr ><th colspan=2 bgcolor=white>Document Length:</th><td colspan=2 bgcolor=white>Variable</td></tr>
<tr ><th colspan=2 bgcolor=white>Concurrency Level:</th><td colspan=2 bgcolor=white>1000</td></tr>
<tr ><th colspan=2 bgcolor=white>Time taken for tests:</th><td colspan=2 bgcolor=white>22.658 seconds</td></tr>
<tr ><th colspan=2 bgcolor=white>Complete requests:</th><td colspan=2 bgcolor=white>10000</td></tr>
<tr ><th colspan=2 bgcolor=white>Failed requests:</th><td colspan=2 bgcolor=white>0</td></tr>
<tr ><th colspan=2 bgcolor=white>Non-2xx responses:</th><td colspan=2 bgcolor=white>10000</td></tr>
<tr ><th colspan=2 bgcolor=white>Keep-Alive requests:</th><td colspan=2 bgcolor=white>10000</td></tr>
<tr ><th colspan=2 bgcolor=white>Total transferred:</th><td colspan=2 bgcolor=white>4897955 bytes</td></tr>
<tr ><th colspan=2 bgcolor=white>HTML transferred:</th><td colspan=2 bgcolor=white>2008065 bytes</td></tr>
<tr ><th colspan=2 bgcolor=white>Requests per second:</th><td colspan=2 bgcolor=white>441.34</td></tr>
<tr ><th colspan=2 bgcolor=white>Transfer rate:</th><td colspan=2 bgcolor=white>211.10 kb/s received</td></tr>
<tr ><th bgcolor=white colspan=4>Connection Times (ms)</th></tr>
<tr ><th bgcolor=white>&nbsp;</th> <th bgcolor=white>min</th>   <th bgcolor=white>avg</th>   <th bgcolor=white>max</th></tr>
<tr ><th bgcolor=white>Connect:</th><td bgcolor=white>    0</td><td bgcolor=white>    3</td><td bgcolor=white>   44</td></tr>
<tr ><th bgcolor=white>Processing:</th><td bgcolor=white>  393</td><td bgcolor=white> 1189</td><td bgcolor=white>10092</td></tr>
<tr ><th bgcolor=white>Total:</th><td bgcolor=white>  393</td><td bgcolor=white> 1192</td><td bgcolor=white>10136</td></tr>
</table>


```