### PR TITLE
Metrics Refactor and record metrics around L1 Server-Timings

### DIFF
--- a/fetcher.go
+++ b/fetcher.go
@@ -137,7 +137,7 @@ func (p *pool) fetchResource(ctx context.Context, from string, resource string, 
 				fetchDurationPerCarPerPeerSuccessMetric.WithLabelValues(cacheStatus).Observe(float64(response_success_end.Sub(start).Milliseconds()))
 			}
 
-			updateSuccessServerTimingMetrics(respHeader.Values(servertiming.HeaderKey), resourceType, cacheStatus, durationMs, ttfbMs, received)
+			updateSuccessServerTimingMetrics(respHeader.Values(servertiming.HeaderKey), resourceType, isCacheHit, durationMs, ttfbMs, received)
 		} else {
 			if isBlockRequest {
 				fetchDurationPerBlockPerPeerFailureMetric.Observe(float64(time.Since(start).Milliseconds()))
@@ -270,7 +270,7 @@ func (p *pool) fetchResource(ctx context.Context, from string, resource string, 
 }
 
 // todo: refactor for dryness
-func updateSuccessServerTimingMetrics(timingHeaders []string, resourceType string, cache_status string, totalTimeMs, ttfbMs int64, recieved int) {
+func updateSuccessServerTimingMetrics(timingHeaders []string, resourceType string, isCacheHit bool, totalTimeMs, ttfbMs int64, recieved int) {
 	if len(timingHeaders) == 0 {
 		goLogger.Error("no timing headers found")
 		return
@@ -281,14 +281,21 @@ func updateSuccessServerTimingMetrics(timingHeaders []string, resourceType strin
 			for _, m := range subReqTiming.Metrics {
 				switch m.Name {
 				case "shim_lassie_headers":
-					fetchDurationPerPeerSuccessCacheMissTotalLassieMetric.WithLabelValues(resourceType).Observe(float64(m.Duration.Milliseconds()))
-				case "nginx":
-					fetchDurationPerPeerSuccessTotalL1NodeMetric.WithLabelValues(resourceType, cache_status).Observe(float64(m.Duration.Milliseconds()))
-					networkTimeMs := totalTimeMs - m.Duration.Milliseconds()
-					fetchNetworkSpeedPerPeerSuccessMetric.WithLabelValues(resourceType).Observe(float64(recieved) / float64(networkTimeMs))
+					if m.Duration.Milliseconds() != 0 && !isCacheHit {
+						fetchDurationPerPeerSuccessCacheMissTotalLassieMetric.WithLabelValues(resourceType).Observe(float64(m.Duration.Milliseconds()))
+					}
 
-					networkLatencyMs := ttfbMs - m.Duration.Milliseconds()
-					fetchNetworkLatencyPeerSuccessMetric.WithLabelValues(resourceType).Observe(float64(networkLatencyMs))
+				case "nginx":
+					// sanity checks
+					if totalTimeMs != 0 && ttfbMs != 0 && m.Duration.Milliseconds() != 0 {
+						fetchDurationPerPeerSuccessTotalL1NodeMetric.WithLabelValues(resourceType, getCacheStatus(isCacheHit)).Observe(float64(m.Duration.Milliseconds()))
+						networkTimeMs := totalTimeMs - m.Duration.Milliseconds()
+						if networkTimeMs > 0 {
+							fetchNetworkSpeedPerPeerSuccessMetric.WithLabelValues(resourceType).Observe(float64(recieved) / float64(networkTimeMs))
+						}
+						networkLatencyMs := ttfbMs - m.Duration.Milliseconds()
+						fetchNetworkLatencyPeerSuccessMetric.WithLabelValues(resourceType).Observe(float64(networkLatencyMs))
+					}
 				default:
 				}
 			}

--- a/metrics.go
+++ b/metrics.go
@@ -160,6 +160,19 @@ var (
 		Help:    "Time spent in Lassie for a Saturn L1 Nginx cache miss for a successful fetch per peer in milliseconds",
 		Buckets: durationMsPerCarHistogram,
 	}, []string{"resourceType"})
+
+	// network timing
+	fetchNetworkSpeedPerPeerSuccessMetric = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    prometheus.BuildFQName("ipfs", "caboose", "fetch_network_speed_peer_success"),
+		Help:    "Network speed observed during successful caboose fetches from a single peer in bytes per milliseconds",
+		Buckets: speedBytesPerMsHistogram,
+	}, []string{"resourceType"})
+
+	fetchNetworkLatencyPeerSuccessMetric = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    prometheus.BuildFQName("ipfs", "caboose", "fetch_network_latency_peer_success"),
+		Help:    "Network latency observed during successful caboose fetches from a single peer in milliseconds",
+		Buckets: durationMsPerCarHistogram,
+	}, []string{"resourceType"})
 )
 
 var CabooseMetrics = prometheus.NewRegistry()
@@ -189,4 +202,7 @@ func init() {
 
 	CabooseMetrics.MustRegister(fetchDurationPerPeerSuccessTotalL1NodeMetric)
 	CabooseMetrics.MustRegister(fetchDurationPerPeerSuccessCacheMissTotalLassieMetric)
+
+	CabooseMetrics.MustRegister(fetchNetworkSpeedPerPeerSuccessMetric)
+	CabooseMetrics.MustRegister(fetchNetworkLatencyPeerSuccessMetric)
 }

--- a/pool.go
+++ b/pool.go
@@ -17,9 +17,7 @@ import (
 	"github.com/serialx/hashring"
 )
 
-var (
-	maxPoolSize = 300
-)
+const maxPoolSize = 300
 
 // loadPool refreshes the set of Saturn endpoints in the pool by fetching an updated list of responsive Saturn nodes from the
 // Saturn Orchestrator.
@@ -207,7 +205,7 @@ func (p *pool) doRefresh() {
 				return int64(int64(n[i].weight)*n[i].addedAt.Unix()) > int64(int64(n[j].weight)*n[j].addedAt.Unix())
 			})
 			n = n[:maxPoolSize]
-			goLogger.Infow(fmt.Sprintf("trimmed pool size to %d", maxPoolSize), "first", n[0].url, "first_weight",
+			goLogger.Infow("trimmed pool size", "pool-size", maxPoolSize, "first", n[0].url, "first_weight",
 				n[0].weight, "last", n[maxPoolSize-1].url, "last_weight", n[maxPoolSize-1].weight)
 		}
 


### PR DESCRIPTION
Some refactor/fixes of the metrics code for correctness/grokability/dryness
Add more dimensions/labels to metrics to better capture block/car, cache-hit/cache-miss  cases
Record prometheus metrics around important L1 server-timings