### PR TITLE
feat: open telemetry tracing

### DIFF
--- a/caboose.go
+++ b/caboose.go
@@ -14,6 +14,8 @@ import (
 	gateway "github.com/ipfs/boxo/gateway"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type Config struct {
@@ -256,10 +258,16 @@ func (c *Caboose) Close() {
 
 // Fetch allows fetching car archives by a path of the form `/ipfs/<cid>[/path/to/file]`
 func (c *Caboose) Fetch(ctx context.Context, path string, cb DataCallback) error {
+	ctx, span := spanTrace(ctx, "Blockstore.Fetch", trace.WithAttributes(attribute.String("path", path)))
+	defer span.End()
+
 	return c.pool.fetchResourceWith(ctx, path, cb, c.getAffinity(ctx))
 }
 
 func (c *Caboose) Has(ctx context.Context, it cid.Cid) (bool, error) {
+	ctx, span := spanTrace(ctx, "Blockstore.Has", trace.WithAttributes(attribute.Stringer("cid", it)))
+	defer span.End()
+
 	blk, err := c.pool.fetchBlockWith(ctx, it, c.getAffinity(ctx))
 	if err != nil {
 		return false, err
@@ -268,6 +276,9 @@ func (c *Caboose) Has(ctx context.Context, it cid.Cid) (bool, error) {
 }
 
 func (c *Caboose) Get(ctx context.Context, it cid.Cid) (blocks.Block, error) {
+	ctx, span := spanTrace(ctx, "Blockstore.Get", trace.WithAttributes(attribute.Stringer("cid", it)))
+	defer span.End()
+
 	blk, err := c.pool.fetchBlockWith(ctx, it, c.getAffinity(ctx))
 	if err != nil {
 		return nil, err
@@ -277,6 +288,9 @@ func (c *Caboose) Get(ctx context.Context, it cid.Cid) (blocks.Block, error) {
 
 // GetSize returns the CIDs mapped BlockSize
 func (c *Caboose) GetSize(ctx context.Context, it cid.Cid) (int, error) {
+	ctx, span := spanTrace(ctx, "Blockstore.GetSize", trace.WithAttributes(attribute.Stringer("cid", it)))
+	defer span.End()
+
 	blk, err := c.pool.fetchBlockWith(ctx, it, c.getAffinity(ctx))
 	if err != nil {
 		return 0, err

--- a/caboose.go
+++ b/caboose.go
@@ -258,14 +258,14 @@ func (c *Caboose) Close() {
 
 // Fetch allows fetching car archives by a path of the form `/ipfs/<cid>[/path/to/file]`
 func (c *Caboose) Fetch(ctx context.Context, path string, cb DataCallback) error {
-	ctx, span := spanTrace(ctx, "Blockstore.Fetch", trace.WithAttributes(attribute.String("path", path)))
+	ctx, span := spanTrace(ctx, "Fetch", trace.WithAttributes(attribute.String("path", path)))
 	defer span.End()
 
 	return c.pool.fetchResourceWith(ctx, path, cb, c.getAffinity(ctx))
 }
 
 func (c *Caboose) Has(ctx context.Context, it cid.Cid) (bool, error) {
-	ctx, span := spanTrace(ctx, "Blockstore.Has", trace.WithAttributes(attribute.Stringer("cid", it)))
+	ctx, span := spanTrace(ctx, "Has", trace.WithAttributes(attribute.Stringer("cid", it)))
 	defer span.End()
 
 	blk, err := c.pool.fetchBlockWith(ctx, it, c.getAffinity(ctx))
@@ -276,7 +276,7 @@ func (c *Caboose) Has(ctx context.Context, it cid.Cid) (bool, error) {
 }
 
 func (c *Caboose) Get(ctx context.Context, it cid.Cid) (blocks.Block, error) {
-	ctx, span := spanTrace(ctx, "Blockstore.Get", trace.WithAttributes(attribute.Stringer("cid", it)))
+	ctx, span := spanTrace(ctx, "Get", trace.WithAttributes(attribute.Stringer("cid", it)))
 	defer span.End()
 
 	blk, err := c.pool.fetchBlockWith(ctx, it, c.getAffinity(ctx))
@@ -288,7 +288,7 @@ func (c *Caboose) Get(ctx context.Context, it cid.Cid) (blocks.Block, error) {
 
 // GetSize returns the CIDs mapped BlockSize
 func (c *Caboose) GetSize(ctx context.Context, it cid.Cid) (int, error) {
-	ctx, span := spanTrace(ctx, "Blockstore.GetSize", trace.WithAttributes(attribute.Stringer("cid", it)))
+	ctx, span := spanTrace(ctx, "GetSize", trace.WithAttributes(attribute.Stringer("cid", it)))
 	defer span.End()
 
 	blk, err := c.pool.fetchBlockWith(ctx, it, c.getAffinity(ctx))

--- a/fetcher.go
+++ b/fetcher.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/influxdata/tdigest"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/google/uuid"
 	blocks "github.com/ipfs/go-block-format"
@@ -81,6 +83,9 @@ func (p *pool) fetchResource(ctx context.Context, from string, resource string, 
 		fetchRequestContextErrorTotalMetric.WithLabelValues(resourceType, fmt.Sprintf("%t", errors.Is(ce, context.Canceled)), "fetchResource-init").Add(1)
 		return ce
 	}
+
+	ctx, span := spanTrace(ctx, "Pool.FetchResource", trace.WithAttributes(attribute.String("from", from), attribute.String("of", resource), attribute.String("mime", mime)))
+	defer span.End()
 
 	requestId := uuid.NewString()
 	goLogger.Debugw("doing fetch", "from", from, "of", resource, "mime", mime, "requestId", requestId)

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,8 @@ require (
 	github.com/stretchr/testify v1.8.2
 	github.com/tcnksm/go-httpstat v0.2.0
 	github.com/urfave/cli/v2 v2.24.2
+	go.opentelemetry.io/otel v1.14.0
+	go.opentelemetry.io/otel/trace v1.14.0
 )
 
 require (
@@ -100,8 +102,6 @@ require (
 	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/otel v1.14.0 // indirect
-	go.opentelemetry.io/otel/trace v1.14.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect

--- a/tracing.go
+++ b/tracing.go
@@ -1,0 +1,15 @@
+package caboose
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var tracer = otel.Tracer("caboose")
+
+func spanTrace(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	return tracer.Start(ctx, fmt.Sprintf("Caboose.%s", spanName), opts...)
+}


### PR DESCRIPTION
Adds Open Telemetry tracing spans. Context: https://github.com/ipfs/bifrost-gateway/issues/68#issuecomment-1504921191.

This is not necessarily required. On the screenshot below you see the tracing result from the Bifrost Gateway up until the HTTP request Caboose makes to the Saturn node. What this PR adds is the `Caboose.*` trace spans. The HTTP GET already worked.

![Screenshot 2023-04-12 at 11 19 18](https://user-images.githubusercontent.com/5447088/231413770-1258a7d8-1e87-454c-8b0c-e53768b1cc5c.png)

@lidel @willscott not sure where is the most value to put the spans here, but this seems like a good start. Feel free to add/remove some.