### PR TITLE
Prevent pool starvation during duress and record CAR response size vs TTFB

### DIFF
--- a/caboose.go
+++ b/caboose.go
@@ -20,7 +20,8 @@ import (
 )
 
 const (
-	EnvironmentKey = "STRN_ENV_TAG"
+	STRN_ENV_KEY   = "STRN_ENV_TAG"
+	CLIENT_ENV_KEY = "CLIENT_ENV"
 )
 
 type Config struct {

--- a/caboose.go
+++ b/caboose.go
@@ -20,8 +20,7 @@ import (
 )
 
 const (
-	STRN_ENV_KEY   = "STRN_ENV_TAG"
-	CLIENT_ENV_KEY = "CLIENT_ENV"
+	STRN_ENV_KEY = "STRN_ENV_TAG"
 )
 
 type Config struct {
@@ -69,10 +68,6 @@ type Config struct {
 
 	TieredHashingOpts []tieredhashing.Option
 }
-
-const DefaultLoggingInterval = 5 * time.Second
-
-const DefaultSaturnOrchestratorRequestTimeout = 30 * time.Second
 
 const DefaultSaturnBlockRequestTimeout = 19 * time.Second
 const DefaultSaturnCarRequestTimeout = 30 * time.Minute

--- a/caboose.go
+++ b/caboose.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	STRN_ENV_KEY = "STRN_ENV_TAG"
+	SaturnEnvKey = "STRN_ENV_TAG"
 )
 
 type Config struct {

--- a/caboose.go
+++ b/caboose.go
@@ -78,7 +78,7 @@ const DefaultSaturnCarRequestTimeout = 30 * time.Minute
 const DefaultMaxRetries = 3
 
 const maxBlockSize = 4194305 // 4 Mib + 1 byte
-const DefaultOrchestratorEndpoint = "https://orchestrator.strn.pl/nodes/nearby?count=1000"
+const DefaultOrchestratorEndpoint = "https://orchestrator.strn.pl/nodes/nearby?count=200"
 const DefaultPoolRefreshInterval = 5 * time.Minute
 
 // we cool off sending requests to Saturn for a cid for a certain duration

--- a/caboose.go
+++ b/caboose.go
@@ -69,6 +69,9 @@ type Config struct {
 	TieredHashingOpts []tieredhashing.Option
 }
 
+const DefaultLoggingInterval = 5 * time.Second
+const DefaultSaturnOrchestratorRequestTimeout = 30 * time.Second
+
 const DefaultSaturnBlockRequestTimeout = 19 * time.Second
 const DefaultSaturnCarRequestTimeout = 30 * time.Minute
 

--- a/caboose_test.go
+++ b/caboose_test.go
@@ -84,9 +84,7 @@ func TestFetchBlock(t *testing.T) {
 		return true
 	}, http.StatusNotAcceptable)
 
-	// one node gets evicted as correctness window is full
 	h.fetchAndAssertFailure(t, ctx, testCid, "406")
-	h.assertPoolSize(t, 0, 2, 2)
 }
 
 func (h *CabooseHarness) assertLatencyCount(t *testing.T, expected int) {

--- a/fetcher.go
+++ b/fetcher.go
@@ -34,6 +34,16 @@ const (
 	resourceTypeBlock   = "block"
 )
 
+var (
+	// 256 Kib to 8Gib
+	carSizes = []float64{262144, 524288, 1.048576e+06, 2.097152e+06, 4.194304e+06,
+		8.388608e+06, 1.6777216e+07, 3.3554432e+07, 6.7108864e+07, 1.34217728e+08,
+		2.68435456e+08, 5.36870912e+08, 1.073741824e+09, 2.147483648e+09, 4.294967296e+09, 8.589934592e+09}
+
+	carSizesStr = []string{"256.0 Kib", "512.0 Kib", "1.0 Mib", "2.0 Mib",
+		"4.0 Mib", "8.0 Mib", "16.0 Mib", "32.0 Mib", "64.0 Mib", "128.0 Mib", "256.0 Mib", "512.0 Mib", "1.0 Gib", "2.0 Gib", "4.0 Gib", "8.0 Gib"}
+)
+
 // doFetch attempts to fetch a block from a given Saturn endpoint. It sends the retrieval logs to the logging endpoint upon a successful or failed attempt.
 func (p *pool) doFetch(ctx context.Context, from string, c cid.Cid, attempt int) (b blocks.Block, rm tieredhashing.ResponseMetrics, e error) {
 	reqUrl := fmt.Sprintf(saturnReqTmpl, c)
@@ -163,7 +173,16 @@ func (p *pool) fetchResource(ctx context.Context, from string, resource string, 
 				fetchTTFBPerBlockPerPeerSuccessMetric.WithLabelValues(cacheStatus).Observe(float64(ttfbMs))
 				fetchDurationPerBlockPerPeerSuccessMetric.WithLabelValues(cacheStatus).Observe(float64(response_success_end.Sub(start).Milliseconds()))
 			} else {
-				fetchTTFBPerCARPerPeerSuccessMetric.WithLabelValues(cacheStatus).Observe(float64(ttfbMs))
+				ci := 0
+				for index, value := range carSizes {
+					if float64(received) < value {
+						ci = index
+						break
+					}
+				}
+				carSizeStr := carSizesStr[ci]
+
+				fetchTTFBPerCARPerPeerSuccessMetric.WithLabelValues(cacheStatus, carSizeStr).Observe(float64(ttfbMs))
 				fetchDurationPerCarPerPeerSuccessMetric.WithLabelValues(cacheStatus).Observe(float64(response_success_end.Sub(start).Milliseconds()))
 			}
 

--- a/fetcher.go
+++ b/fetcher.go
@@ -247,8 +247,10 @@ func (p *pool) fetchResource(ctx context.Context, from string, resource string, 
 		}
 	}
 
+	agent := req.Header.Get("User-Agent")
+	req.Header.Set("User-Agent", os.Getenv(STRN_ENV_KEY)+"/"+agent)
+
 	//trace
-	req.Header.Add(CLIENT_ENV_KEY, os.Getenv(STRN_ENV_KEY))
 	req = req.WithContext(httpstat.WithHTTPStat(req.Context(), &result))
 
 	var resp *http.Response

--- a/fetcher.go
+++ b/fetcher.go
@@ -210,7 +210,7 @@ func (p *pool) fetchResource(ctx context.Context, from string, resource string, 
 				// my address
 				Range:          "",
 				Referrer:       respReq.Referer(),
-				UserAgent:      "bifrost-" + os.Getenv(EnvironmentKey) + respReq.UserAgent(),
+				UserAgent:      respReq.UserAgent(),
 				NodeId:         saturnNodeId,
 				NodeIpAddress:  from,
 				IfNetworkError: networkError,
@@ -246,10 +246,9 @@ func (p *pool) fetchResource(ctx context.Context, from string, resource string, 
 			}
 		}
 	}
-	agent := req.Header.Get("User-Agent")
-	req.Header.Set("User-Agent", " bifrost-"+os.Getenv(EnvironmentKey)+agent)
 
 	//trace
+	req.Header.Add(CLIENT_ENV_KEY, os.Getenv(STRN_ENV_KEY))
 	req = req.WithContext(httpstat.WithHTTPStat(req.Context(), &result))
 
 	var resp *http.Response

--- a/metrics.go
+++ b/metrics.go
@@ -138,7 +138,7 @@ var (
 		Name:    prometheus.BuildFQName("ipfs", "caboose", "fetch_ttfb_car_peer_success"),
 		Help:    "TTFB observed during a successful caboose CAR fetch from a single peer in milliseconds",
 		Buckets: durationMsPerCarHistogram,
-	}, []string{"cache_status"})
+	}, []string{"cache_status", "car_size"})
 
 	// failure
 	fetchDurationPerCarPerPeerFailureMetric = prometheus.NewHistogram(prometheus.HistogramOpts{

--- a/metrics.go
+++ b/metrics.go
@@ -233,6 +233,7 @@ func init() {
 	CabooseMetrics.MustRegister(poolRemovedReadFailureTotalMetric)
 	CabooseMetrics.MustRegister(poolRemovedNon2xxTotalMetric)
 	CabooseMetrics.MustRegister(poolMembersNotAddedBecauseRemovedMetric)
+	CabooseMetrics.MustRegister(poolMembersRemovedAndAddedBackMetric)
 	CabooseMetrics.MustRegister(poolEnoughObservationsForMainSetDurationMetric)
 	CabooseMetrics.MustRegister(poolTierChangeMetric)
 

--- a/pool.go
+++ b/pool.go
@@ -209,7 +209,7 @@ func (p *pool) fetchBlockWith(ctx context.Context, c cid.Cid, with string) (blk 
 	p.lk.RLock()
 	nodes := p.th.GetNodes(aff, p.config.MaxRetrievalAttempts)
 	p.lk.RUnlock()
-	if len(nodes) < p.config.MaxRetrievalAttempts {
+	if len(nodes) == 0 {
 		return nil, ErrNoBackend
 	}
 

--- a/pool.go
+++ b/pool.go
@@ -103,9 +103,10 @@ func (p *pool) refreshWithNodes(newEP []string) {
 	distLk.Lock()
 	defer distLk.Unlock()
 
-	added, alreadyRemoved := p.th.AddOrchestratorNodes(newEP)
+	added, alreadyRemoved, back := p.th.AddOrchestratorNodes(newEP)
 	poolNewMembersMetric.Set(float64(added))
 	poolMembersNotAddedBecauseRemovedMetric.Set(float64(alreadyRemoved))
+	poolMembersRemovedAndAddedBackMetric.Set(float64(back))
 
 	// update the tier set
 	mu, um := p.th.UpdateMainTierWithTopN()

--- a/pool_metrics.go
+++ b/pool_metrics.go
@@ -25,6 +25,10 @@ var (
 		Name: prometheus.BuildFQName("ipfs", "caboose", "pool_members_not_added"),
 	})
 
+	poolMembersRemovedAndAddedBackMetric = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: prometheus.BuildFQName("ipfs", "caboose", "pool_removed_and_added_back"),
+	})
+
 	poolRefreshErrorMetric = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: prometheus.BuildFQName("ipfs", "caboose", "pool_refresh_errors"),
 		Help: "Number of errors refreshing the caboose pool",

--- a/pool_refresh_test.go
+++ b/pool_refresh_test.go
@@ -32,7 +32,7 @@ func TestPoolRefresh(t *testing.T) {
 	// removed node is NOT added back as pool is  full without it
 	andAndAssertPool(t, p, []string{"node1", "node2", "node3", "node4", "node5", "node6"}, 0, 5, 5, 0)
 	nds := p.th.GetPerf()
-	for node, _ := range nds {
+	for node := range nds {
 		require.NotEqual(t, "node4", node)
 	}
 

--- a/pool_refresh_test.go
+++ b/pool_refresh_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestPoolRefresh(t *testing.T) {
-	opts := []tieredhashing.Option{tieredhashing.WithCorrectnessWindowSize(1)}
+	opts := []tieredhashing.Option{tieredhashing.WithCorrectnessWindowSize(1), tieredhashing.WithMaxPoolSize(5)}
 
 	p := newPool(&Config{TieredHashingOpts: opts})
 
@@ -27,7 +27,15 @@ func TestPoolRefresh(t *testing.T) {
 	// record failure so that node is removed and then assert
 	rm := p.th.RecordFailure("node4", tieredhashing.ResponseMetrics{ConnFailure: true})
 	require.NotNil(t, rm)
-	andAndAssertPool(t, p, []string{"node1", "node2", "node3", "node4", "node5"}, 0, 4, 4, 0)
+	require.EqualValues(t, "node4", rm.Node)
+
+	// removed node is NOT added back as pool is  full without it
+	andAndAssertPool(t, p, []string{"node1", "node2", "node3", "node4", "node5", "node6"}, 0, 5, 5, 0)
+	nds := p.th.GetPerf()
+	for node, _ := range nds {
+		require.NotEqual(t, "node4", node)
+	}
+
 }
 
 func TestPoolRefreshWithLatencyDistribution(t *testing.T) {

--- a/tieredhashing/tiered_hashing_test.go
+++ b/tieredhashing/tiered_hashing_test.go
@@ -424,12 +424,13 @@ func TestAddOrchestratorNodes(t *testing.T) {
 	th.addNewNodesAll(t, nodes2)
 	th.assertSize(t, 0, 20)
 
-	th.addAndAssert(t, append(nodes[:3], nodes2[:3]...), 0, 0, 0, 20)
+	th.addAndAssert(t, append(nodes[:3], nodes2[:3]...), 0, 0, 0, 0, 20)
 
 	th.h.removeFailedNode(nodes[0])
 	th.assertSize(t, 0, 19)
 
-	th.addAndAssert(t, append(nodes[:3], nodes2[:3]...), 0, 1, 0, 19)
+	// removed node gets added back as we are not full
+	th.addAndAssert(t, append(nodes[:3], nodes2[:3]...), 1, 1, 1, 0, 20)
 }
 
 func TestAddOrchestratorNodesMax(t *testing.T) {
@@ -437,13 +438,13 @@ func TestAddOrchestratorNodesMax(t *testing.T) {
 
 	// empty -> 10 get added
 	nodes := th.genNodes(t, 30)
-	a, _ := th.h.AddOrchestratorNodes(nodes)
+	a, _, _ := th.h.AddOrchestratorNodes(nodes)
 	require.EqualValues(t, 10, a)
 	th.assertSize(t, 0, 10)
 
 	// nothing gets added as we are full
 	nodes2 := th.genNodes(t, 30)
-	a, _ = th.h.AddOrchestratorNodes(append(nodes, nodes2...))
+	a, _, _ = th.h.AddOrchestratorNodes(append(nodes, nodes2...))
 	require.EqualValues(t, 0, a)
 	th.assertSize(t, 0, 10)
 
@@ -454,18 +455,19 @@ func TestAddOrchestratorNodesMax(t *testing.T) {
 	th.assertSize(t, 0, 8)
 
 	// 2 get added now
-	a, _ = th.h.AddOrchestratorNodes(append(nodes, nodes2...))
+	a, _, _ = th.h.AddOrchestratorNodes(append(nodes, nodes2...))
 	require.EqualValues(t, 2, a)
 	th.assertSize(t, 0, 10)
 
-	// removed node does not get added back
 	th.h.removeFailedNode(nodes[2])
 	th.assertSize(t, 0, 9)
 
-	a, ar := th.h.AddOrchestratorNodes(nodes[:10])
-	require.EqualValues(t, 0, a)
+	// removed node does not get added back as we are already full without it
+	a, ar, back := th.h.AddOrchestratorNodes(append(nodes, "newnode"))
+	require.EqualValues(t, 1, a)
 	require.EqualValues(t, 3, ar)
-	th.assertSize(t, 0, 9)
+	th.assertSize(t, 0, 10)
+	require.EqualValues(t, 0, back)
 }
 
 type TieredHashingHarness struct {
@@ -502,17 +504,19 @@ func (th *TieredHashingHarness) addNewNodesAll(t *testing.T, nodes []string) {
 		old = append(old, key)
 	}
 
-	added, already := th.h.AddOrchestratorNodes(append(nodes, old...))
+	added, already, _ := th.h.AddOrchestratorNodes(append(nodes, old...))
 	require.Zero(t, already)
 	require.EqualValues(t, len(nodes), added)
 }
 
-func (th *TieredHashingHarness) addAndAssert(t *testing.T, nodes []string, added, already int, main, unknown int) {
-	a, ar := th.h.AddOrchestratorNodes(nodes)
+func (th *TieredHashingHarness) addAndAssert(t *testing.T, nodes []string, added, already, ab int, main, unknown int) {
+	a, ar, addedBack := th.h.AddOrchestratorNodes(nodes)
 	require.EqualValues(t, added, a)
 
 	require.EqualValues(t, already, ar)
 	th.assertSize(t, main, unknown)
+
+	require.EqualValues(t, ab, addedBack)
 }
 
 func (th *TieredHashingHarness) assertSize(t *testing.T, main int, unknown int) {


### PR DESCRIPTION
- Add back the nodes we've kicked out if they're the only option we have to fill the pool. However, do it in descending order of reputation as determined by the orchestrator.
-  Let's plot CAR response size vs TTFB to visualise the co-relation there if any.
- Let's use a `CLIENT_ENV` header instead of `User-Agent` for debugging/metrics on L1s.