### PR TITLE
Add ErrInvalidResponse

### DIFF
--- a/caboose.go
+++ b/caboose.go
@@ -162,6 +162,11 @@ func (epr ErrPartialResponse) Error() string {
 	return "caboose received a partial response"
 }
 
+// ErrInvalidResponse can be returned from a DataCallback to indicate that the data provided for the
+// requested resource was explicitly 'incorrect' - that blocks not in the requested dag, or non-car-conforming
+// data was returned.
+type ErrInvalidResponse error
+
 type Caboose struct {
 	config *Config
 	pool   *pool


### PR DESCRIPTION
An explicit error for signaling that the wrong data was returned