### PR TITLE
Forward otel tracing to sub requests

### DIFF
--- a/fetcher.go
+++ b/fetcher.go
@@ -12,7 +12,9 @@ import (
 	"time"
 
 	"github.com/filecoin-saturn/caboose/tieredhashing"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/google/uuid"
@@ -261,6 +263,7 @@ func (p *pool) fetchResource(ctx context.Context, from string, resource string, 
 
 	//trace
 	req = req.WithContext(httpstat.WithHTTPStat(req.Context(), &result))
+	otel.GetTextMapPropagator().Inject(req.Context(), propagation.HeaderCarrier(req.Header))
 
 	var resp *http.Response
 	saturnCallsTotalMetric.WithLabelValues(resourceType).Add(1)


### PR DESCRIPTION
I think we may have been doing this previously by setting the [ExtraHeaders](https://github.com/filecoin-saturn/caboose/blob/main/fetcher.go#L251)

but this seems like a better pattern.

