### PR TITLE
report size of response body only, exclude headers

### DIFF
--- a/fetcher.go
+++ b/fetcher.go
@@ -146,10 +146,6 @@ func (p *pool) fetchResource(ctx context.Context, from string, resource string, 
 			if cacheHit == saturnCacheHit {
 				isCacheHit = true
 			}
-
-			for k, v := range respHeader {
-				received = received + len(k) + len(v)
-			}
 		}
 
 		durationSecs := time.Since(start).Seconds()


### PR DESCRIPTION
Including header sizes in response size makes it hard to do byte-for-byte comparisons between different services sending the same CAR file.