### PR TITLE
Relative correctness policy in Caboose

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -147,6 +147,8 @@ func (p *pool) refreshWithNodes(newEP []tieredhashing.NodeInfo) {
 	poolMembersNotAddedBecauseRemovedMetric.Set(float64(alreadyRemoved))
 	poolMembersRemovedAndAddedBackMetric.Set(float64(back))
 
+	p.th.UpdateAverageCorrectnessPct()
+
 	// update the tier set
 	mu, um := p.th.UpdateMainTierWithTopN()
 	poolTierChangeMetric.WithLabelValues(tierMainToUnknown).Set(float64(mu))

--- a/pool_refresh_test.go
+++ b/pool_refresh_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestPoolRefresh(t *testing.T) {
-	opts := []tieredhashing.Option{tieredhashing.WithCorrectnessWindowSize(1), tieredhashing.WithMaxPoolSize(5)}
+	opts := []tieredhashing.Option{tieredhashing.WithCorrectnessWindowSize(1), tieredhashing.WithMaxPoolSize(5), tieredhashing.WithCorrectnessThreshold(10)}
 
 	p := newPool(&Config{TieredHashingOpts: opts})
 
@@ -25,6 +25,10 @@ func TestPoolRefresh(t *testing.T) {
 
 	// add a new node with already added nodes
 	andAndAssertPool(t, p, []string{"node1", "node2", "node3", "node4", "node5"}, 0, 5, 5, 1)
+
+	p.th.RecordSuccess("node1", tieredhashing.ResponseMetrics{TTFBMs: 10})
+	p.th.RecordSuccess("node1", tieredhashing.ResponseMetrics{TTFBMs: 10})
+	p.th.UpdateAverageCorrectnessPct()
 
 	// record failure so that node is removed and then assert
 	rm := p.th.RecordFailure("node4", tieredhashing.ResponseMetrics{ConnFailure: true})

--- a/tieredhashing/config.go
+++ b/tieredhashing/config.go
@@ -8,9 +8,9 @@ type TieredHashingConfig struct {
 	FailureDebounce       time.Duration
 	LatencyWindowSize     int
 	CorrectnessWindowSize int
-	CorrectnessPct        float64
 	MaxMainTierSize       int
 	NoRemove              bool
+	CorrectnessThreshold  float64
 }
 
 type Option func(config *TieredHashingConfig)
@@ -33,9 +33,9 @@ func WithMaxMainTierSize(n int) Option {
 	}
 }
 
-func WithCorrectnessPct(pct float64) Option {
+func WithCorrectnessThreshold(pct float64) Option {
 	return func(c *TieredHashingConfig) {
-		c.CorrectnessPct = pct
+		c.CorrectnessThreshold = pct
 	}
 }
 

--- a/tieredhashing/tiered_hashing.go
+++ b/tieredhashing/tiered_hashing.go
@@ -362,6 +362,12 @@ func (t *TieredHashing) MoveBestUnknownToMain() int {
 }
 
 func (t *TieredHashing) UpdateAverageCorrectnessPct() {
+	if t.NOverAllCorrectnessDigest < float64(t.cfg.CorrectnessWindowSize) {
+		t.AverageCorrectnessPct = 0
+		return
+	}
+	t.NOverAllCorrectnessDigest = float64(t.cfg.CorrectnessWindowSize)
+
 	averageSuccess := t.OverAllCorrectnessDigest.Reduce(func(w rolling.Window) float64 {
 		var result float64
 		for _, bucket := range w {

--- a/tieredhashing/tiered_hashing.go
+++ b/tieredhashing/tiered_hashing.go
@@ -27,7 +27,7 @@ const (
 	reasonCorrectness = "correctness"
 
 	// use rolling windows for latency and correctness calculations
-	latencyWindowSize     = 100
+	latencyWindowSize     = 50
 	correctnessWindowSize = 1000
 
 	// ------------------ CORRECTNESS -------------------

--- a/tieredhashing/tiered_hashing.go
+++ b/tieredhashing/tiered_hashing.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 	"time"
 
+	golog "github.com/ipfs/go-log/v2"
+
 	"github.com/asecurityteam/rolling"
-
 	"github.com/patrickmn/go-cache"
-
 	"github.com/serialx/hashring"
 )
 
@@ -36,7 +36,11 @@ const (
 
 	// helps shield nodes against bursty failures
 	failureDebounce = 2 * time.Second
-	removalDuration = 3 * time.Hour
+	removalDuration = 6 * time.Hour
+)
+
+var (
+	goLogger = golog.Logger("caboose-pool")
 )
 
 type Tier string
@@ -376,6 +380,7 @@ func (t *TieredHashing) UpdateAverageCorrectnessPct() {
 func (t *TieredHashing) UpdateMainTierWithTopN() (mainToUnknown, unknownToMain int) {
 	// sort all nodes by P95 and pick the top N as main tier nodes
 	nodes := t.nodesSortedLatency()
+	goLogger.Infow("UpdateMainTierWithTopN: number of nodes with enough latency observations", "n", len(nodes))
 	if len(nodes) == 0 {
 		return
 	}

--- a/tieredhashing/tiered_hashing.go
+++ b/tieredhashing/tiered_hashing.go
@@ -27,7 +27,7 @@ const (
 	reasonCorrectness = "correctness"
 
 	// use rolling windows for latency and correctness calculations
-	latencyWindowSize     = 50
+	latencyWindowSize     = 100
 	correctnessWindowSize = 1000
 
 	// ------------------ CORRECTNESS -------------------

--- a/tieredhashing/tiered_hashing.go
+++ b/tieredhashing/tiered_hashing.go
@@ -439,7 +439,7 @@ func (t *TieredHashing) isCorrectnessPolicyEligible(perf *NodePerf) (float64, bo
 	// should satisfy a certain minimum percentage
 	pct := totalSuccess / perf.NCorrectnessDigest * 100
 
-	return pct, (avePct - pct) > t.cfg.CorrectnessThreshold
+	return pct, (avePct - pct) < t.cfg.CorrectnessThreshold
 }
 
 func (t *TieredHashing) removeFailedNode(node string) (mc, uc int) {

--- a/tieredhashing/tiered_hashing.go
+++ b/tieredhashing/tiered_hashing.go
@@ -40,7 +40,7 @@ const (
 )
 
 var (
-	goLogger = golog.Logger("caboose-pool")
+	goLogger = golog.Logger("caboose-tiered-hashing")
 )
 
 type Tier string
@@ -454,6 +454,9 @@ func (t *TieredHashing) isCorrectnessPolicyEligible(perf *NodePerf) (float64, bo
 	// should satisfy a certain minimum percentage
 	pct := totalSuccess / perf.NCorrectnessDigest * 100
 
+	// This function returns true when a node is eligible for the correctness policy and should be retained.
+	// If this function returns false, it means that the node is not eligible for the correctness policy and should be removed.
+	// So we return true here only if the difference between the average pool correctness and the node correctness is less than the acceptable threshold.
 	return pct, (t.AverageCorrectnessPct - pct) < t.cfg.CorrectnessThreshold
 }
 

--- a/tieredhashing/tiered_hashing_test.go
+++ b/tieredhashing/tiered_hashing_test.go
@@ -80,7 +80,8 @@ func TestRecordFailure(t *testing.T) {
 	require.Nil(t, th.h.RecordFailure(unknownNode, ResponseMetrics{NetworkError: true}))
 	require.EqualValues(t, 1, th.h.nodes[unknownNode].networkErrors)
 
-	// node is evicted as we have enough observations
+	// node is evicted as we have enough observations and it's correctness is below threshold acceptance
+	th.h.AverageCorrectnessPct = 80
 	rm := th.h.RecordFailure(unknownNode, ResponseMetrics{NetworkError: true})
 	require.NotNil(t, rm)
 	require.EqualValues(t, TierUnknown, rm.Tier)
@@ -172,7 +173,7 @@ func TestNodeNotRemovedWithVar(t *testing.T) {
 func TestNodeEvictionWithWindowing(t *testing.T) {
 	window := 4
 
-	th := NewTieredHashingHarness(WithCorrectnessWindowSize(window), WithFailureDebounce(0), WithCorrectnessThreshold(80))
+	th := NewTieredHashingHarness(WithCorrectnessWindowSize(window), WithFailureDebounce(0), WithCorrectnessThreshold(30))
 	// main node
 	unknownNode := th.genAndAddAll(t, 1)[0]
 	th.assertSize(t, 0, 1)
@@ -186,9 +187,12 @@ func TestNodeEvictionWithWindowing(t *testing.T) {
 	th.h.RecordSuccess(unknownNode, ResponseMetrics{})
 	th.h.RecordSuccess(unknownNode, ResponseMetrics{})
 	th.h.RecordSuccess(unknownNode, ResponseMetrics{})
+	rm := th.h.RecordFailure(unknownNode, ResponseMetrics{NetworkError: true})
+	require.Nil(t, rm)
 
 	// evicted as pct < 80 because of windowing
-	rm := th.h.RecordFailure(unknownNode, ResponseMetrics{NetworkError: true})
+	th.h.AverageCorrectnessPct = 100
+	rm = th.h.RecordFailure(unknownNode, ResponseMetrics{NetworkError: true})
 	require.NotNil(t, rm)
 	require.EqualValues(t, TierMain, rm.Tier)
 	require.EqualValues(t, unknownNode, rm.Node)
@@ -392,10 +396,11 @@ func TestIsCorrectnessPolicyEligible(t *testing.T) {
 	window := 10
 
 	tcs := map[string]struct {
-		perf    *NodePerf
-		correct bool
-		pct     float64
-		initF   func(perf *NodePerf)
+		perf                  *NodePerf
+		correct               bool
+		pct                   float64
+		initF                 func(perf *NodePerf)
+		averageCorrectnessPct float64
 	}{
 		"no observations": {
 			perf:    &NodePerf{},
@@ -429,8 +434,29 @@ func TestIsCorrectnessPolicyEligible(t *testing.T) {
 			perf: &NodePerf{
 				CorrectnessDigest: rolling.NewPointPolicy(rolling.NewWindow(int(window))),
 			},
-			correct: false,
-			pct:     20,
+			correct:               false,
+			pct:                   20,
+			averageCorrectnessPct: 45,
+		},
+		"some success and success as above threshold": {
+			initF: func(perf *NodePerf) {
+				perf.CorrectnessDigest.Append(1)
+				perf.NCorrectnessDigest++
+				perf.CorrectnessDigest.Append(1)
+				perf.NCorrectnessDigest++
+
+				for i := 0; i < int(window)-2; i++ {
+					perf.CorrectnessDigest.Append(0)
+					perf.NCorrectnessDigest++
+				}
+
+			},
+			perf: &NodePerf{
+				CorrectnessDigest: rolling.NewPointPolicy(rolling.NewWindow(int(window))),
+			},
+			correct:               true,
+			pct:                   20,
+			averageCorrectnessPct: 40,
 		},
 		"some success but not enough observations": {
 			initF: func(perf *NodePerf) {
@@ -475,6 +501,7 @@ func TestIsCorrectnessPolicyEligible(t *testing.T) {
 			if tc.initF != nil {
 				tc.initF(tc.perf)
 			}
+			th.h.AverageCorrectnessPct = tc.averageCorrectnessPct
 
 			perf := tc.perf
 			pct, ok := th.h.isCorrectnessPolicyEligible(perf)

--- a/tieredhashing/tiered_hashing_test.go
+++ b/tieredhashing/tiered_hashing_test.go
@@ -170,6 +170,28 @@ func TestNodeNotRemovedWithVar(t *testing.T) {
 	th.assertSize(t, 0, 1)
 }
 
+func TestUpdateAverageCorrectnessPct(t *testing.T) {
+	window := 2
+
+	th := NewTieredHashingHarness(WithCorrectnessWindowSize(window), WithFailureDebounce(0), WithCorrectnessThreshold(30))
+	node := th.genAndAddAll(t, 1)[0]
+
+	th.h.UpdateAverageCorrectnessPct()
+	require.Zero(t, th.h.AverageCorrectnessPct)
+
+	th.h.RecordSuccess(node, ResponseMetrics{Success: true})
+	th.h.UpdateAverageCorrectnessPct()
+	require.Zero(t, th.h.AverageCorrectnessPct)
+
+	th.h.RecordSuccess(node, ResponseMetrics{Success: true})
+	th.h.UpdateAverageCorrectnessPct()
+	require.EqualValues(t, 100, th.h.AverageCorrectnessPct)
+
+	th.h.RecordFailure(node, ResponseMetrics{NetworkError: true})
+	th.h.UpdateAverageCorrectnessPct()
+	require.EqualValues(t, 50, th.h.AverageCorrectnessPct)
+}
+
 func TestNodeEvictionWithWindowing(t *testing.T) {
 	window := 4
 

--- a/tieredhashing/tiered_hashing_test.go
+++ b/tieredhashing/tiered_hashing_test.go
@@ -172,7 +172,7 @@ func TestNodeNotRemovedWithVar(t *testing.T) {
 func TestNodeEvictionWithWindowing(t *testing.T) {
 	window := 4
 
-	th := NewTieredHashingHarness(WithCorrectnessWindowSize(window), WithFailureDebounce(0), WithCorrectnessPct(80))
+	th := NewTieredHashingHarness(WithCorrectnessWindowSize(window), WithFailureDebounce(0), WithCorrectnessThreshold(80))
 	// main node
 	unknownNode := th.genAndAddAll(t, 1)[0]
 	th.assertSize(t, 0, 1)


### PR DESCRIPTION
We don't want to evict nodes if their correctness is similar to other nodes even if their absolute correctness is below a certain random threshold as software bugs can cause absolute correctness to dip which will result in us evicting legit nodes.