### PR TITLE
Increase mirrored requests and prevent main set from starvation during DDOS

### DIFF
--- a/caboose.go
+++ b/caboose.go
@@ -89,7 +89,7 @@ const DefaultSaturnCarRequestTimeout = 30 * time.Minute
 const defaultMaxRetries = 3
 
 // default percentage of requests to mirror for tracking how nodes perform unless overridden by MirrorFraction
-const defaultMirrorFraction = 0.01
+const defaultMirrorFraction = 0.03
 
 const maxBlockSize = 4194305 // 4 Mib + 1 byte
 const DefaultOrchestratorEndpoint = "https://orchestrator.strn.pl/nodes?maxNodes=200"

--- a/caboose.go
+++ b/caboose.go
@@ -84,7 +84,7 @@ const DefaultSaturnOrchestratorRequestTimeout = 30 * time.Second
 
 const DefaultSaturnBlockRequestTimeout = 19 * time.Second
 const DefaultSaturnCarRequestTimeout = 30 * time.Minute
-const DefaultSaturnMirrorRequestTimeout = 2 * time.Minute
+const DefaultSaturnMirrorRequestTimeout = 30 * time.Second
 
 // default retries before failure unless overridden by MaxRetrievalAttempts
 const defaultMaxRetries = 3

--- a/caboose.go
+++ b/caboose.go
@@ -84,13 +84,13 @@ const DefaultSaturnOrchestratorRequestTimeout = 30 * time.Second
 
 const DefaultSaturnBlockRequestTimeout = 19 * time.Second
 const DefaultSaturnCarRequestTimeout = 30 * time.Minute
-const DefaultSaturnMirrorRequestTimeout = DefaultSaturnCarRequestTimeout / 3
+const DefaultSaturnMirrorRequestTimeout = 2 * time.Minute
 
 // default retries before failure unless overridden by MaxRetrievalAttempts
 const defaultMaxRetries = 3
 
 // default percentage of requests to mirror for tracking how nodes perform unless overridden by MirrorFraction
-const defaultMirrorFraction = 0.03
+const defaultMirrorFraction = 0.02
 
 const maxBlockSize = 4194305 // 4 Mib + 1 byte
 const DefaultOrchestratorEndpoint = "https://orchestrator.strn.pl/nodes?maxNodes=200"

--- a/caboose.go
+++ b/caboose.go
@@ -84,6 +84,7 @@ const DefaultSaturnOrchestratorRequestTimeout = 30 * time.Second
 
 const DefaultSaturnBlockRequestTimeout = 19 * time.Second
 const DefaultSaturnCarRequestTimeout = 30 * time.Minute
+const DefaultSaturnMirrorRequestTimeout = DefaultSaturnCarRequestTimeout / 3
 
 // default retries before failure unless overridden by MaxRetrievalAttempts
 const defaultMaxRetries = 3

--- a/pool.go
+++ b/pool.go
@@ -264,6 +264,7 @@ func (p *pool) checkPool() {
 
 				cancel()
 				if err != nil {
+					goLogger.Warnw("mirrored request failed", "err", err.Error())
 					mirroredTrafficTotalMetric.WithLabelValues("error").Inc()
 				} else {
 					mirroredTrafficTotalMetric.WithLabelValues("no-error").Inc()

--- a/pool.go
+++ b/pool.go
@@ -259,7 +259,7 @@ func (p *pool) checkPool() {
 					return
 				}
 				p.lk.RUnlock()
-				trialTimeout, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				trialTimeout, cancel := context.WithTimeout(context.Background(), DefaultSaturnMirrorRequestTimeout)
 				err := p.fetchResourceAndUpdate(trialTimeout, node, msg.path, 0, p.mirrorValidator)
 
 				cancel()

--- a/tieredhashing/tiered_hashing.go
+++ b/tieredhashing/tiered_hashing.go
@@ -381,6 +381,7 @@ func (t *TieredHashing) UpdateAverageCorrectnessPct() {
 	})
 	avePct := averageSuccess / t.NOverAllCorrectnessDigest * 100
 	t.AverageCorrectnessPct = avePct
+	goLogger.Infow("UpdateAverageCorrectnessPct", "AverageCorrectnessPct", t.AverageCorrectnessPct)
 }
 
 func (t *TieredHashing) UpdateMainTierWithTopN() (mainToUnknown, unknownToMain int) {
@@ -465,6 +466,9 @@ func (t *TieredHashing) isCorrectnessPolicyEligible(perf *NodePerf) (float64, bo
 
 	// should satisfy a certain minimum percentage
 	pct := totalSuccess / perf.NCorrectnessDigest * 100
+
+	goLogger.Infow("isCorrectnessPolicyEligible", "pct", pct, "avg", t.AverageCorrectnessPct, "threshold", t.cfg.CorrectnessThreshold,
+		"node", perf.IP)
 
 	// This function returns true when a node is eligible for the correctness policy and should be retained.
 	// If this function returns false, it means that the node is not eligible for the correctness policy and should be removed.

--- a/tieredhashing/tiered_hashing.go
+++ b/tieredhashing/tiered_hashing.go
@@ -428,6 +428,18 @@ func (t *TieredHashing) UpdateMainTierWithTopN() (mainToUnknown, unknownToMain i
 		}
 	}
 
+	// if we don't have enough nodes for the main pool, compromise on number of observations required and fill it up
+	if t.mainSet.Size() < t.cfg.MaxMainTierSize {
+		for {
+			cnt := t.MoveBestUnknownToMain()
+			unknownToMain = unknownToMain + cnt
+
+			if cnt == 0 || t.mainSet.Size() == t.cfg.MaxMainTierSize {
+				break
+			}
+		}
+	}
+
 	return
 }
 


### PR DESCRIPTION
<img width="838" alt="image" src="https://github.com/filecoin-saturn/caboose/assets/3341710/1638a02e-8b08-4625-8dc6-66fd35f6c5da">
Need to investigate high error rate in mirrored requests. Have added logging here for that.