### PR TITLE
Increase pool size now that mirroring is actually working

### DIFF
--- a/tieredhashing/tiered_hashing.go
+++ b/tieredhashing/tiered_hashing.go
@@ -15,7 +15,7 @@ import (
 
 // TODO Make env vars for tuning
 const (
-	maxPoolSize                 = 50
+	maxPoolSize                 = 200
 	maxMainTierSize             = 25
 	PLatency                    = 90
 	PMaxLatencyWithoutWindowing = 100
@@ -27,7 +27,7 @@ const (
 	reasonCorrectness = "correctness"
 
 	// use rolling windows for latency and correctness calculations
-	latencyWindowSize     = 100
+	latencyWindowSize     = 50
 	correctnessWindowSize = 1000
 
 	// ------------------ CORRECTNESS -------------------


### PR DESCRIPTION
Now that mirroring is actually working, we can increase pool size and afford to have more unknown nodes in the pool as we will test them with a good cadence and promote them to main if they do better than what we have in main.