### PR TITLE
Add a core attribute to tracing span

### DIFF
--- a/fetcher.go
+++ b/fetcher.go
@@ -101,8 +101,11 @@ func (p *pool) fetchResource(ctx context.Context, from string, resource string, 
 		fetchRequestContextErrorTotalMetric.WithLabelValues(resourceType, fmt.Sprintf("%t", errors.Is(ce, context.Canceled)), "fetchResource-init").Add(1)
 		return rm, ce
 	}
+	p.lk.RLock()
+	isCore := p.th.IsCore(from)
+	p.lk.RUnlock()
 
-	ctx, span := spanTrace(ctx, "Pool.FetchResource", trace.WithAttributes(attribute.String("from", from), attribute.String("of", resource), attribute.String("mime", mime)))
+	ctx, span := spanTrace(ctx, "Pool.FetchResource", trace.WithAttributes(attribute.String("from", from), attribute.String("of", resource), attribute.String("mime", mime), attribute.Bool("core", isCore)))
 	defer span.End()
 
 	requestId := uuid.NewString()

--- a/tieredhashing/tiered_hashing.go
+++ b/tieredhashing/tiered_hashing.go
@@ -52,6 +52,7 @@ type NodeInfo struct {
 	Distance      float32 `json:"distance"`
 	Weight        int     `json:"weight"`
 	ComplianceCid string  `json:"complianceCid"`
+	Core          bool    `json:"core"`
 }
 
 type NodePerf struct {
@@ -529,4 +530,12 @@ func (t *TieredHashing) recordCorrectness(perf *NodePerf, success bool) {
 		t.UpdateAverageCorrectnessPct()
 		t.LastAverageCalcAt = time.Now()
 	}
+}
+
+func (t *TieredHashing) IsCore(n string) bool {
+	nd, ok := t.nodes[n]
+	if !ok {
+		return false
+	}
+	return nd.Core
 }


### PR DESCRIPTION
the configured orchestrator url will also need to be updated in infra, but this will take a 'core' attribute when present on a node and propagate it to the submitted trace for relevant sub requests